### PR TITLE
Operator now supports device files outside the /dev

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -1,6 +1,4 @@
-FROM docker.io/fedora:29
-
-COPY extras/release6-fedora.repo /etc/yum.repos.d/glusterfs-6-rc0.repo
+FROM docker.io/fedora:30
 
 RUN yum update -y && \
     yum -y install procps-ng glusterfs-fuse xfsprogs && \

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:29
+FROM docker.io/fedora:30
 
 COPY extras/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,4 @@
-FROM docker.io/fedora:29
-
-COPY extras/release6-fedora.repo /etc/yum.repos.d/glusterfs-6-rc0.repo
+FROM docker.io/fedora:30
 
 RUN yum update -y && \
     yum -y install python3-pyxattr procps-ng glusterfs-server xfsprogs && \

--- a/server/glusterfsd.py
+++ b/server/glusterfsd.py
@@ -88,6 +88,14 @@ def create_and_mount_brick(brick_device, brick_path, brickfs):
     Create brick filesystem and mount the brick. Currently
     only xfs is supported
     """
+
+    # If brick device path is not starts with /dev then use
+    # /brickdev prefix. Brick device directory passed by the user
+    # is mounted as /brickdev to avoid mixing with any other
+    # dirs inside container.
+    if not brick_device.startswith("/dev/"):
+        brick_device = "/brickdev/" + os.path.basename(brick_device)
+
     if brickfs == "xfs":
         try:
             execute("mkfs.xfs", brick_device)
@@ -114,7 +122,7 @@ def start():
     """
     brick_device = os.environ.get("BRICK_DEVICE", None)
     brick_path = os.environ["BRICK_PATH"]
-    if brick_device is not None or brick_device != "":
+    if brick_device is not None and brick_device != "":
         brickfs = os.environ.get("BRICK_FS", "xfs")
         create_and_mount_brick(brick_device, brick_path, brickfs)
 

--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -68,9 +68,13 @@ spec:
               readOnly: true
             - name: glusterfsd-volfilesdir
               mountPath: "/var/lib/gluster"
-            - name: glusterfsd-datadir
-              mountPath: "/bricks"
+            - name: glusterfsd-mountdir
+              mountPath: "/bricks/{{ volname }}"
               mountPropagation: Bidirectional
+{%- if brick_device_dir != "" %}
+            - name: brick-device-dir
+              mountPath: "/brickdev"
+{%- endif %}
         - name: quotad
           image: docker.io/{{ docker_user }}/kadalu-server:{{ kadalu_version }}
           env:
@@ -94,8 +98,8 @@ spec:
             capabilities: {}
             privileged: true
           volumeMounts:
-            - name: glusterfsd-datadir
-              mountPath: "/bricks"
+            - name: glusterfsd-mountdir
+              mountPath: "/bricks/{{ volname }}"
               mountPropagation: Bidirectional
       volumes:
         - name: gluster-dev
@@ -110,11 +114,17 @@ spec:
         - name: glusterfsd-volfilesdir
           configMap:
             name: "kadalu-info"
-        - name: glusterfsd-datadir
-{% if brick_device == "" %}
+        - name: glusterfsd-mountdir
+{%- if brick_device == "" %}
           hostPath:
             path: "{{ host_brick_path }}"
             type: Directory
-{% else %}
+{%- else %}
           emptyDir: {}
-{% endif %}
+{%- endif %}
+{%- if brick_device_dir != "" %}
+        - name: brick-device-dir
+          hostPath:
+            path: "{{ brick_device_dir }}"
+            type: Directory
+{%- endif %}


### PR DESCRIPTION
- If device file is specified is outside `/dev` then Operator will
  mount the parent directory of file to server container.
- Incremented the Fedora version to 30 so that it will pull the latest
  stable gluster version(6.3)
- `include_uninitialized` argument is removed in latest kubernetes python
  client. So removed from Operator code.

Signed-off-by: Aravinda VK <mail@aravindavk.in>