### PR TITLE
Do not restart sample app if Completed without error

### DIFF
--- a/examples/sample-app.yaml
+++ b/examples/sample-app.yaml
@@ -18,3 +18,4 @@ spec:
   - name: csivol
     persistentVolumeClaim:
       claimName: pv1
+  restartPolicy: OnFailure


### PR DESCRIPTION
Sample app completes without error, but restarts since the
default restart policy is always. Add restart policy as
OnFailure to prevent restarts.

```
$ kubectl get pods
NAME   READY   STATUS      RESTARTS   AGE
pod1   0/1     Completed   0          2m13s
```

Logs:

```
$ kubectl logs pod1
This is a sample application
Filesystem      Size  Used Avail Use% Mounted on
/dev/loop1      474M   25M  449M   6% /mnt/pv
/mnt/sp3/virtblock/2e/c9/pvc-31020fa1-748c-4a18-a781-4e8b8a992580 \
    on /mnt/pv type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
Write/Read test on PV mount
Fri Jul 12 11:47:55 UTC 2019
SUCCESS
```

Signed-off-by: Aravinda VK <mail@aravindavk.in>