### PR TITLE
csi: make gluster mount with --auto-invalidation off

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -427,6 +427,7 @@ def mount_glusterfs(volume, target_path):
     cmd = [
         GLUSTERFS_CMD,
         "--process-name", "fuse",
+        "-l", "/dev/stdout",
         "--volfile-id=%s" % volume,
         target_path,
         "-f", "%s/%s.client.vol" % (VOLFILES_DIR, volume)

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -428,6 +428,7 @@ def mount_glusterfs(volume, target_path):
         GLUSTERFS_CMD,
         "--process-name", "fuse",
         "-l", "/dev/stdout",
+        "--auto-invalidation", "off",
         "--volfile-id=%s" % volume,
         target_path,
         "-f", "%s/%s.client.vol" % (VOLFILES_DIR, volume)


### PR DESCRIPTION
This makes use of kernel's fuse cache.

Refer: `git show a229ee1c8cdf8e0ac1abaeb60cabe6ab08f60546` for more
info on this. considering each directory is handled differently, this
may make sense here.

Tag: Experimental

Fixes: #11
Signed-off-by: Amar Tumballi <amarts@gmail.com>