### PR TITLE
enable tracker for operator and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ pv1    Bound    pvc-8cbe80f1-428f-11e9-b31e-525400f59aef   1Gi        RWO       
 
 ### KaDalu Storage Export Pod
 ![KaDalu Server Pod](doc/server-pod.png)
+
+## NOTE
+
+We are tracking the number of downloads based on 'docker pull' stats, and also through google analytics. [Issue #16])(issues/16) gives detail of what is added to code w.r.to tracking.

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -10,7 +10,7 @@ RUN yum update -y && \
     rm -rf /var/cache/yum
 
 # Install Python GRPC library and copy all CSI related files
-RUN python3 -m pip install kubernetes jinja2 xxhash
+RUN python3 -m pip install kubernetes jinja2 xxhash requests
 RUN mkdir -p /kadalu/manifests
 
 COPY templates/services.yaml.j2      /kadalu/templates/services.yaml.j2

--- a/operator/main.py
+++ b/operator/main.py
@@ -7,6 +7,7 @@ import os
 import uuid
 import json
 import logging
+import requests
 
 from kubernetes import client, config, watch
 from jinja2 import Template
@@ -312,6 +313,21 @@ def deploy_storage_class():
     execute(KUBECTL_CMD, "create", "-f", filename)
     logging.info(logf("Deployed StorageClass", manifest=filename))
 
+def send_analytics_tracker(ga_id):
+    reqheader = { 'user-agent': 'Kadalu-App', 'accept': '*/*' }
+    url = "https://www.google-analytics.com/collect?v=1&t=pageview"
+    epoch = time.time()
+    track_page = "http://kadalu.org/kadalu-operator"
+    track_title = "Kadalu Operator"
+    track_url = "%s&tid=%s&cid=1363&z=%d&dl=%s&dt=%s" % (url, ga_id, epoch, track_page, track_title)
+
+    # TODO: make this optional, and let users know this operator tracks one run as 1 page hit.
+    try:
+        s = requests.get(track_url, reqheader)
+    except:
+        True
+    # ignore s
+
 
 def main():
     """Main"""
@@ -319,6 +335,12 @@ def main():
 
     core_v1_client = client.CoreV1Api()
     k8s_client = client.ApiClient()
+
+    # Send Analytics Tracker
+    # The information from this analytics is available for
+    # developers to understand and build project in a better
+    # way
+    send_analytics_tracker("GA-144588868-1")
 
     # ConfigMap
     deploy_config_map(core_v1_client)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y && \
     rm -rf /var/cache/yum && \
     rpm -qa | grep gluster | tee /gluster-rpm-versions.txt
 
-RUN python3 -m pip install jinja2 xxhash
+RUN python3 -m pip install jinja2 xxhash requests
 
 COPY lib/kadalulib.py        /kadalu/kadalulib.py
 COPY server/server.py        /kadalu/server.py

--- a/server/glusterfsd.py
+++ b/server/glusterfsd.py
@@ -6,6 +6,7 @@ import uuid
 import sys
 import json
 import logging
+import requests
 
 from jinja2 import Template
 import xattr
@@ -116,6 +117,22 @@ def create_and_mount_brick(brick_device, brick_path, brickfs):
         execute("mount", "-oprjquota", brick_device, mountdir)
 
 
+def send_analytics_tracker(ga_id):
+    reqheader = { 'user-agent': 'Kadalu-App', 'accept': '*/*' }
+    url = "https://www.google-analytics.com/collect?v=1&t=pageview"
+    epoch = time.time()
+    track_page = "http://kadalu.org/kadalu-server"
+    track_title = "Kadalu Server"
+    track_url = "%s&tid=%s&cid=1363&z=%d&dl=%s&dt=%s" % (url, ga_id, epoch, track_page, track_title)
+
+    # TODO: make this optional, and let users know this operator tracks one run as 1 page hit.
+    try:
+        s = requests.get(track_url, reqheader)
+    except:
+        True
+    # ignore s
+
+
 def start():
     """
     Start the Gluster Brick Process
@@ -138,6 +155,11 @@ def start():
     volfile_id = "%s.%s.%s" % (volname, nodename, brick_path_name)
     volfile_path = os.path.join(VOLFILES_DIR, "%s.vol" % volfile_id)
     generate_brick_volfile(volfile_path, volname)
+
+    # Send Analytics Tracker
+    # The information from this analytics is available for
+    # developers to understand and build project in a better way
+    send_analytics_tracker("GA-144588868-1")
 
     os.execv(
         "/usr/sbin/glusterfsd",

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -130,6 +130,9 @@ test_kadalu)
             break;
         fi
         if [[ $cnt -eq 100 ]]; then
+            kubectl get pods -nkadalu;
+            kubectl get pods;
+            echo "exiting after 100 seconds"
             exit 1;
         fi
     done
@@ -149,6 +152,9 @@ test_kadalu)
             break;
         fi
         if [[ $cnt -eq 100 ]]; then
+            kubectl get pods -nkadalu;
+            kubectl get pods;
+            echo "exiting after 100 seconds"
             exit 1;
         fi
     done


### PR DESCRIPTION
* Tracks 1 page view before starting the server
* Tracks 1 page view after starting operator

Nothing other than page view is tracked. This helps us to enhance
supportability in future by adding k8s version etc in tracker.

Also to be worked on, to make it optional.

Updates: #16

Signed-off-by: Amar Tumballi <amarts@gmail.com>