### PR TITLE
minikube.sh: add more logging to tests

### DIFF
--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -112,28 +112,55 @@ kadalu_operator)
     cp examples/sample-storage-file-device.yaml /tmp/kadalu-storage.yaml
     sed -i -e "s/DISK/${DISK}/g" /tmp/kadalu-storage.yaml
     kubectl create -f /tmp/kadalu-storage.yaml
+    # give it some time
+    cnt=0
+    while true; do
+        cnt=$((cnt+1))
+        sleep 1;
+        ret=`kubectl get pods -nkadalu -o name | wc -l`
+        if [[ $ret -eq 5 ]]; then
+            echo "Successful after $cnt seconds"
+            break;
+        fi
+        if [[ $cnt -eq 100 ]]; then
+            kubectl get pods -nkadalu;
+            kubectl get pods;
+            echo "giving up after 100 seconds"
+            break;
+        fi
+        if [[ $((cnt%10)) -eq 0 ]]; then
+            echo "$cnt: Waiting for pods to come up..."
+        fi
+    done
+
     ;;
 
 test_kadalu)
+    fail=0
     echo "Requesting PVC and Sample apps"
     cp examples/sample-test-app.yaml /tmp/kadalu-test-app.yaml
     # Run ReadWriteOnce test
     kubectl create -f /tmp/kadalu-test-app.yaml
 
     # give it some time
-    cnt=1
+    cnt=0
     while true; do
         cnt=$((cnt+1))
         sleep 1;
         ret=`kubectl get pods pod1 | grep Completed | wc -l`
         if [[ $ret -eq 1 ]]; then
+            echo "Successful after $cnt seconds"
             break;
         fi
         if [[ $cnt -eq 100 ]]; then
             kubectl get pods -nkadalu;
             kubectl get pods;
             echo "exiting after 100 seconds"
-            exit 1;
+            fail=1
+            break;
+        fi
+        if [[ $((cnt%10)) -eq 0 ]]; then
+            echo "$cnt: Waiting for pods to come up..."
         fi
     done
     kubectl logs pod1
@@ -143,22 +170,40 @@ test_kadalu)
     sed -i -e "s/ReadWriteOnce/ReadWriteMany/g" /tmp/kadalu-test-app.yaml
     kubectl create -f /tmp/kadalu-test-app.yaml
     # give it some time
-    cnt=1
+    cnt=0
     while true; do
         cnt=$((cnt+1))
         sleep 1;
         ret=`kubectl get pods pod2 | grep Completed | wc -l`
         if [[ $ret -eq 1 ]]; then
+            echo "Successful after $cnt seconds"
             break;
         fi
         if [[ $cnt -eq 100 ]]; then
             kubectl get pods -nkadalu;
             kubectl get pods;
             echo "exiting after 100 seconds"
-            exit 1;
+            fail=1
+            break;
+        fi
+        if [[ $((cnt%10)) -eq 0 ]]; then
+            echo "$cnt: Waiting for pods to come up..."
         fi
     done
     kubectl logs pod2
+
+    # Log everything so we are sure if things are as expected
+    for p in $(kubectl -n kadalu get pods -o name); do
+        echo "====================== Start $p ======================";
+        kubectl -nkadalu logs $p --all-containers=true;
+        echo "======================= End $p =======================";
+    done
+    #kubectl -n kadalu logs -lapp=kadalu --all-containers=true
+
+    # Return failure if fail variable is set to 1
+    if [ $fail -eq 1 ] ; then
+        exit 1;
+    fi
     ;;
 clean)
     minikube delete


### PR DESCRIPTION
also emit the logs of the containers to the screen at the end of
the tests.

Signed-off-by: Amar Tumballi <amarts@gmail.com>