### PR TITLE
Handle invalid server pod names

### DIFF
--- a/templates/Replica1.client.vol.j2
+++ b/templates/Replica1.client.vol.j2
@@ -13,7 +13,7 @@ volume {{ volname }}-client
     option transport.tcp-user-timeout 42
     option ping-timeout 42
     option filter-O_DIRECT disable
-    option remote-host server-{{ volname }}-{{ bricks[0]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[0]["node"] }}
     option transport.socket.keepalive-interval 2
     option send-gids on
     option transport.socket.nodelay 1

--- a/templates/Replica3.client.vol.j2
+++ b/templates/Replica3.client.vol.j2
@@ -6,7 +6,7 @@ volume {{ volname }}-replicate-0-client-0
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[0]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-0-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[0]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-0-RECON_NO:-0
     option fops-version 1298437
     option transport.socket.ssl-enabled off
     option transport.socket.keepalive-time 20
@@ -18,7 +18,7 @@ volume {{ volname }}-replicate-0-client-0
     option remote-subvolume {{ bricks[0]["brick_path"] }}
     option transport.socket.keepalive-count 9
     option filter-O_DIRECT disable
-    option remote-host server-{{ volname }}-{{ bricks[0]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[0]["node"] }}
     option transport.socket.nodelay 1
     option send-gids on
     option ping-timeout 42
@@ -39,11 +39,11 @@ volume {{ volname }}-replicate-0-client-1
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[1]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-1-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[1]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-1-RECON_NO:-0
     option fops-version 1298437
     option transport.socket.ssl-enabled off
     option frame-timeout 1800
-    option remote-host server-{{ volname }}-{{ bricks[1]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[1]["node"] }}
     option non-blocking-io off
     option remote-subvolume {{ bricks[1]["brick_path"] }}
     option transport.socket.lowlat off
@@ -72,11 +72,11 @@ volume {{ volname }}-replicate-0-client-2
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[2]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-2-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[2]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-2-RECON_NO:-0
     option fops-version 1298437
     option transport-type socket
     option transport.listen-backlog 1024
-    option remote-host server-{{ volname }}-{{ bricks[2]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[2]["node"] }}
     option remote-subvolume {{ bricks[2]["brick_path"] }}
     option transport.socket.keepalive-count 9
     option transport.socket.own-thread off

--- a/templates/Replica3.shd.vol.j2
+++ b/templates/Replica3.shd.vol.j2
@@ -6,7 +6,7 @@ volume {{ volname }}-replicate-0-client-0
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[0]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-0-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[0]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-0-RECON_NO:-0
     option fops-version 1298437
     option transport.socket.ssl-enabled off
     option transport.socket.keepalive-time 20
@@ -18,7 +18,7 @@ volume {{ volname }}-replicate-0-client-0
     option remote-subvolume {{ bricks[0]["brick_path"] }}
     option transport.socket.keepalive-count 9
     option filter-O_DIRECT disable
-    option remote-host server-{{ volname }}-{{ bricks[0]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[0]["node"] }}
     option transport.socket.nodelay 1
     option send-gids on
     option ping-timeout 42
@@ -39,11 +39,11 @@ volume {{ volname }}-replicate-0-client-1
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[1]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-1-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[1]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-1-RECON_NO:-0
     option fops-version 1298437
     option transport.socket.ssl-enabled off
     option frame-timeout 1800
-    option remote-host server-{{ volname }}-{{ bricks[1]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[1]["node"] }}
     option non-blocking-io off
     option remote-subvolume {{ bricks[1]["brick_path"] }}
     option transport.socket.lowlat off
@@ -72,11 +72,11 @@ volume {{ volname }}-replicate-0-client-2
     option volfile-key /{{ volname }}
     option client-version 7dev
     option process-name fuse
-    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:server-{{ volname }}-{{ bricks[2]["node"] }}-0.{{ volname }}-PC_NAME:{{ volname }}-replicate-0-client-2-RECON_NO:-0
+    option process-uuid CTX_ID:9adfef22-2e0c-411f-a979-de075cb3b0db-GRAPH_ID:0-PID:5043-HOST:{{ bricks[2]["node"] }}-PC_NAME:{{ volname }}-replicate-0-client-2-RECON_NO:-0
     option fops-version 1298437
     option transport-type socket
     option transport.listen-backlog 1024
-    option remote-host server-{{ volname }}-{{ bricks[2]["node"] }}-0.{{ volname }}
+    option remote-host {{ bricks[2]["node"] }}
     option remote-subvolume {{ bricks[2]["brick_path"] }}
     option transport.socket.keepalive-count 9
     option transport.socket.own-thread off

--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -3,7 +3,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: server-{{ volname }}-{{ kube_hostname }}
+  name: {{ serverpod_name }}
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/part-of: kadalu


### PR DESCRIPTION
Brick hostname is `<statefulset-name>-<ordinal>.<service-name>`
statefulset name is the one which is visible when the
`get pods` command is run, so the format used for that name
is "`server-<volname>-<hostname>`". Escape dots from the hostname
from the input otherwise will become invalid name
Service is created with name as Volume name. For example,
brick_hostname will be "server-spool1-minikube.spool1" and
server pod name will be "server-spool1-minikube"

Kube hostname will be used for placing server pods to specific Kube
node using Node Affinity.

Fixes: #56
Signed-off-by: Aravinda VK <mail@aravindavk.in>