### PR TITLE
vendor: change from 'kadalu.gluster' to 'org.kadalu.gluster'

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -31,7 +31,7 @@ LABEL name="kadalu-csi"
 LABEL Summary="KaDalu CSI driver"
 LABEL vcs-type="git"
 LABEL vcs-url="https://github.com/kadalu/kadalu"
-LABEL vendor="kadalu.gluster"
+LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
 ENTRYPOINT ["/usr/bin/python3", "/kadalu/main.py"]

--- a/csi/identityserver.py
+++ b/csi/identityserver.py
@@ -5,7 +5,7 @@ import csi_pb2
 import csi_pb2_grpc
 
 
-DRIVER_NAME = "kadalu"
+DRIVER_NAME = "org.kadalu.gluster"
 DRIVER_VERSION = "0.1.0"
 
 

--- a/extras/sample-app/Dockerfile
+++ b/extras/sample-app/Dockerfile
@@ -12,7 +12,7 @@ LABEL name="kadalu-sample-app"
 LABEL Summary="KaDalu Sample App"
 LABEL vcs-type="git"
 LABEL vcs-url="https://github.com/kadalu/kadalu"
-LABEL vendor="kadalu.gluster"
+LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
 ENTRYPOINT ["bash", "/kadalu/script.sh"]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -31,7 +31,7 @@ LABEL name="kadalu-operator"
 LABEL Summary="KaDalu Operator"
 LABEL vcs-type="git"
 LABEL vcs-url="https://github.com/kadalu/kadalu"
-LABEL vendor="kadalu.gluster"
+LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
 ENTRYPOINT ["/usr/bin/python3", "/kadalu/main.py"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -36,7 +36,7 @@ LABEL name="kadalu-server"
 LABEL Summary="KaDalu Server"
 LABEL vcs-type="git"
 LABEL vcs-url="https://github.com/kadalu/kadalu"
-LABEL vendor="kadalu.gluster"
+LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
 ENTRYPOINT ["/usr/bin/python3", "/kadalu/server.py"]


### PR DESCRIPTION
Generally, in both App development (`com.whatsapp` && `org.telegram.messenger`) , and in CSI drivers (ref: https://github.com/kubernetes-csi/docs/blob/master/book/src/drivers.md), the namespace is reserved by keeping reverse order of urls.

Hence I thought it may be better idea to keep the vendor name properly. Note that after this, we may need a re-install, but considering there are no production deployments yet, this may be fine for now. (and I don't foresee a name change later)

Signed-off-by: Amar Tumballi <amarts@gmail.com>