### PR TITLE
External glusterfs storage as PV option

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -12,7 +12,7 @@ import csi_pb2_grpc
 from volumeutils import mount_and_select_hosting_volume, \
     create_virtblock_volume, create_subdir_volume, delete_volume, \
     get_pv_hosting_volumes, PV_TYPE_SUBVOL, PV_TYPE_VIRTBLOCK, \
-    HOSTVOL_MOUNTDIR
+    HOSTVOL_MOUNTDIR, check_external_volume
 from kadalulib import logf
 
 
@@ -30,31 +30,6 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
         ))
         pvsize = request.capacity_range.required_bytes
 
-        # TODO: Check the available space under lock
-
-        # Add everything from parameter as filter item
-        filters = {}
-        for pkey, pvalue in request.parameters.items():
-            filters[pkey] = pvalue
-
-        logging.debug(logf(
-            "Filters applied to choose storage",
-            **filters
-        ))
-        host_volumes = get_pv_hosting_volumes(filters)
-        logging.debug(logf(
-            "Got list of hosting Volumes",
-            volumes=",".join(host_volumes)
-        ))
-
-        hostvol = mount_and_select_hosting_volume(host_volumes, pvsize)
-        if hostvol is None:
-            errmsg = "No Hosting Volumes available, add more storage"
-            logging.error(errmsg)
-            context.set_details(errmsg)
-            context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
-            return csi_pb2.CreateVolumeResponse()
-
         pvtype = PV_TYPE_SUBVOL
         for vol_capability in request.volume_capabilities:
             # using getattr to avoid Pylint error
@@ -69,6 +44,69 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
             pvtype=pvtype,
             capabilities=request.volume_capabilities
         ))
+
+        # TODO: Check the available space under lock
+
+        # Add everything from parameter as filter item
+        filters = {}
+        for pkey, pvalue in request.parameters.items():
+            filters[pkey] = pvalue
+
+        logging.debug(logf(
+            "Filters applied to choose storage",
+            **filters
+        ))
+        ext_volume = None
+        if filters['hostvol_type'] == 'External':
+            ext_volume = check_external_volume(request)
+            if ext_volume:
+                logging.info(logf(
+                    "Volume (External) created",
+                    name=request.name,
+                    size=pvsize,
+                    hostvol=ext_volume['name'],
+                    pvtype=pvtype,
+                    volpath=ext_volume['host'],
+                    duration_seconds=time.time() - start_time
+                ))
+                return csi_pb2.CreateVolumeResponse(
+                    volume={
+                        "volume_id": request.name,
+                        "capacity_bytes": pvsize,
+                        "volume_context": {
+                            "type": "External",
+                            "hostvol": ext_volume['name'],
+                            "pvtype": pvtype,
+                            "path": ext_volume['host'],
+                            "fstype": "xfs",
+                            "options": ext_volume['options'],
+                        }
+                    }
+                )
+
+            logging.debug(logf(
+                "Here as checking external volume failed",
+                external_volume=ext_volume
+            ))
+            errmsg = "External Storage provided not valid"
+            logging.error(errmsg)
+            context.set_details(errmsg)
+            context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
+            return csi_pb2.CreateVolumeResponse()
+
+        host_volumes = get_pv_hosting_volumes(filters)
+        logging.debug(logf(
+            "Got list of hosting Volumes",
+            volumes=",".join(host_volumes)
+        ))
+
+        hostvol = mount_and_select_hosting_volume(host_volumes, pvsize)
+        if hostvol is None:
+            errmsg = "No Hosting Volumes available, add more storage"
+            logging.error(errmsg)
+            context.set_details(errmsg)
+            context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
+            return csi_pb2.CreateVolumeResponse()
 
         if pvtype == PV_TYPE_VIRTBLOCK:
             vol = create_virtblock_volume(
@@ -93,6 +131,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
                 "volume_id": request.name,
                 "capacity_bytes": pvsize,
                 "volume_context": {
+                    "type": filters['hostvol_type'],
                     "hostvol": hostvol,
                     "pvtype": pvtype,
                     "path": vol.volpath,

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -266,7 +266,7 @@ def create_subdir_volume(hostvol_mnt, volname, size):
 
 
 def delete_volume(volname):
-    """Delete virtual block or sub directory volume"""
+    """Delete virtual block, sub directory volume, or External"""
     vol = search_volume(volname)
     if vol is not None:
         logging.debug(logf(
@@ -423,6 +423,30 @@ def mount_glusterfs(volume, target_path):
 
     # Ignore if already mounted
     if os.path.ismount(target_path):
+        logging.debug(logf(
+            "Already mounted",
+            mount=target_path
+        ))
+        return
+
+    # This is just to prevent multiple requests getting here in parallel
+    need_wait = True
+    target_path_lock = "%s.lock" % target_path
+
+    while True:
+        if not os.path.exists(target_path_lock):
+            os.mknod(target_path_lock)
+            need_wait = False
+            break
+        time.sleep(0.2)
+
+    # Ignore if already mounted
+    if os.path.ismount(target_path):
+        logging.debug(logf(
+            "Already mounted (2nd try)",
+            mount=target_path
+        ))
+        os.unlink(target_path_lock)
         return
 
     generate_client_volfile(volume)
@@ -431,7 +455,100 @@ def mount_glusterfs(volume, target_path):
         "--process-name", "fuse",
         "-l", "/dev/stdout",
         "--volfile-id=%s" % volume,
-        target_path,
-        "-f", "%s/%s.client.vol" % (VOLFILES_DIR, volume)
+        "-f", "%s/%s.client.vol" % (VOLFILES_DIR, volume),
+        target_path
     ]
+    try:
+        execute(*cmd)
+    except Exception as e:
+        logging.error(logf(
+            "error to execute command",
+            cmd=cmd,
+            error=format(e)
+        ))
+        os.unlink(target_path_lock)
+        raise e
+
+    os.unlink(target_path_lock)
+    return
+
+def mount_glusterfs_with_host(volume, target_path, host, options=None):
+    """Mount Glusterfs Volume"""
+    if not os.path.exists(target_path):
+        makedirs(target_path)
+
+    # Ignore if already mounted
+    if os.path.ismount(target_path):
+        return
+
+    # FIXME: make this better later (an issue for external contribution)
+    opt_array = None
+    #if options:
+    #    opt_array = []
+    #    for opt in options.split(","):
+    #        if not opt or opt == "":
+    #            break
+    #        for k,v in opt.split("="):
+    #            if k == "log-level":
+    #                opt_array.append("--log-level")
+    #                opt_array.append(v)
+    #                # TODO: handle more options, and document them
+
+    # Fix the log, so we can check it out later
+    # log_file = "/var/log/glusterfs/%s" % target_path.replace("/", "-")
+    log_file = "/dev/stdout"
+    cmd = [
+        GLUSTERFS_CMD,
+        "--process-name", "fuse",
+        "-l", "%s" % log_file,
+        "--volfile-id=%s" % volume,
+        "-s", host,
+        target_path
+    ]
+    #if opt_array:
+    #    cmd.extend(opt_array)
+    #
+    ## add mount point after all options
+    #cmd.append(target_path)
+    logging.debug(logf(
+        "glusterfs command",
+        cmd=cmd
+    ))
+
     execute(*cmd)
+    return
+
+def check_external_volume(pv_request):
+    """Mount hosting volume"""
+    # Assumption is, this has to have 'hostvol_type' as External.
+    params = {}
+    for pkey, pvalue in pv_request.parameters.items():
+        params[pkey] = pvalue
+
+    hvol = {
+        "host": params['gluster_host'],
+        "name": params['gluster_volname'],
+        "options": params['gluster_options'],
+    }
+    hpath = "%s.%s" % (hvol['name'], hvol['host'])
+    mntdir = os.path.join(HOSTVOL_MOUNTDIR, hpath)
+
+    mount_glusterfs_with_host(hvol['name'], mntdir, hvol['host'], hvol['options'])
+    # TODO: fix me
+    time.sleep(2);
+
+    if not os.path.ismount(mntdir):
+        logging.debug(logf(
+            "Mount failed",
+            hvol=hvol,
+            mntdir=mntdir
+        ))
+        return None
+
+    logging.debug(logf(
+        "Mount successful",
+        hvol=hvol
+    ))
+
+    unmount_volume(mntdir)
+    return hvol

--- a/examples/sample-external-storage.yaml
+++ b/examples/sample-external-storage.yaml
@@ -1,0 +1,45 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kadalu.external.pv-ext # Keep changing the name for different volumes
+provisioner: kadalu
+parameters:
+  hostvol_type: "External"
+  gluster_host: gluster1.kadalu.io   # Change to your gluster host
+  gluster_volname: test              # Change to existing gluster volume
+  gluster_options: log-level=DEBUG   # Comma separated options
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv-ext
+spec:
+  storageClassName: kadalu.external.pv-ext
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Mi # This gets ignored in this case.
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ext
+  labels:
+    app: sample-app
+spec:
+  containers:
+  - name: sample-app
+    image: docker.io/kadalu/sample-pv-check-app:latest
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - mountPath: "/mnt/pv"
+      name: csivol
+  volumes:
+  - name: csivol
+    persistentVolumeClaim:
+      claimName: pv-ext
+  restartPolicy: OnFailure

--- a/examples/sample-test-app1.yaml
+++ b/examples/sample-test-app1.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 300Mi
 # -*- mode: yaml -*-
 ---
 kind: PersistentVolumeClaim
@@ -23,7 +23,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 500Mi
 # -*- mode: yaml -*-
 ---
 apiVersion: v1
@@ -59,9 +59,9 @@ spec:
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - mountPath: "/mnt/pv"
-      name: csivol
+      name: csivol1
   volumes:
-  - name: csivol
+  - name: csivol1
     persistentVolumeClaim:
       claimName: pv1-2
   restartPolicy: OnFailure

--- a/examples/sample-test-app3.yaml
+++ b/examples/sample-test-app3.yaml
@@ -10,7 +10,8 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 600Mi
+
 ---
 apiVersion: v1
 kind: Pod
@@ -43,7 +44,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 800Mi
+
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -164,13 +164,24 @@ test_kadalu)
     # Run ReadWriteOnce test
     kubectl create -f /tmp/kadalu-test-app1.yaml
 
+    echo "Running sample test app (Replica3) yml from repo "
+    cp examples/sample-test-app3.yaml /tmp/kadalu-test-app3.yaml
+    # Run ReadWriteOnce test
+    kubectl create -f /tmp/kadalu-test-app3.yaml
     # give it some time
+
+    echo "Running sample test app from external Gluster"
+    cp examples/sample-external-storage.yaml /tmp/kadalu-test-app-ext.yaml
+    # Run ReadWriteOnce test
+    kubectl create -f /tmp/kadalu-test-app-ext.yaml
+    # give it some time
+
     cnt=0
     while true; do
         cnt=$((cnt + 1))
         sleep 1
-        ret=$(kubectl get pods pod1-1 pod1-2 | grep 'Completed' | wc -l)
-        if [[ $ret -eq 2 ]]; then
+        ret=$(kubectl get pods | grep 'Completed' | wc -l)
+        if [[ $ret -eq 5 ]]; then
             echo "Successful after $cnt seconds"
             break
         fi
@@ -178,7 +189,7 @@ test_kadalu)
 	    kubectl get pvc
             kubectl get pods -nkadalu
             kubectl get pods
-            echo "exiting after 100 seconds"
+            echo "exiting after 200 seconds"
             fail=1
             break
         fi
@@ -186,52 +197,38 @@ test_kadalu)
             echo "$cnt: Waiting for pods to come up..."
         fi
     done
-
-    echo "Running sample test app (Replica3) yml from repo "
-    cp examples/sample-test-app3.yaml /tmp/kadalu-test-app3.yaml
-    # Run ReadWriteOnce test
-    kubectl create -f /tmp/kadalu-test-app3.yaml
-    # give it some time
-    cnt=0
-    while true; do
-        cnt=$((cnt + 1))
-        sleep 1
-        ret=$(kubectl get pods pod3-1 pod3-2 | grep 'Completed' | wc -l)
-        if [[ $ret -eq 2 ]]; then
-            echo "Successful after $cnt seconds"
-            break
-        fi
-        if [[ $cnt -eq 200 ]]; then
-	    kubectl get pvc
-            kubectl get pods -nkadalu;
-            kubectl get pods;
-            echo "exiting after 100 seconds"
-            fail=1
-            break
-        fi
-        if [[ $((cnt % 25)) -eq 0 ]]; then
-            echo "$cnt: Waiting for pods to come up..."
-        fi
-    done
+    kubectl get pvc
+    kubectl get pods
 
     # Log everything so we are sure if things are as expected
     for p in $(kubectl -n kadalu get pods -o name); do
         echo "====================== Start $p ======================"
-        kubectl -nkadalu logs $p --all-containers=true
+        kubectl -nkadalu --all-containers=true --tail 100 logs $p
         echo "======================= End $p ======================="
     done
 
-    echo "---- Logs from pod3 ----"
+    echo "---- Logs from pod3 & pod1 ----"
+    kubectl describe pod pod-ext
+    echo "------------------"
     kubectl describe pod pod3-1
+    echo "------------------"
     kubectl describe pod pod3-2
-    kubectl logs pod3-1
-    kubectl logs pod3-2
-    echo "---- Logs from pod1 ----"
+    echo "------------------"
     kubectl describe pod pod1-1
+    echo "------------------"
     kubectl describe pod pod1-2
+    echo "------------------"
+
+    kubectl logs pod-ext
+    echo "------------------"
+    kubectl logs pod3-1
+    echo "------------------"
+    kubectl logs pod3-2
+    echo "------------------"
     kubectl logs pod1-1
+    echo "------------------"
     kubectl logs pod1-2
-    #kubectl -n kadalu logs -lapp=kadalu --all-containers=true
+    echo "------------------"
 
     date
 


### PR DESCRIPTION
Currently for each existing gluster volume, one needs to provide
a different storage class, as specified in the example file.

In future we can extend this to also create newer glusterfs subvols
to provide PVs.

This is just to validate our concept that if there is a PV provisioned
using heketi project, or statically provisioned by glusterd, one can use the same glusterfs volume with kadalu in newer k8s version.

Updates: #36

Signed-off-by: Amar Tumballi <amar@kadalu.io>