### PR TITLE
operator: deploy storage pod on top of PVC

### DIFF
--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/name: server
     spec:
       serviceAccountName: kadalu-server-sa
+{%- if kube_hostname != "" %}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -33,6 +34,8 @@ spec:
                   operator: In
                   values:
                     - {{ kube_hostname }}
+{%- endif %}
+
       containers:
         - name: glusterfsd
           image: docker.io/{{ docker_user }}/kadalu-server:{{ kadalu_version }}
@@ -80,6 +83,7 @@ spec:
             - name: brick-device-dir
               mountPath: "/brickdev"
 {%- endif %}
+
         - name: quotad
           image: docker.io/{{ docker_user }}/kadalu-server:{{ kadalu_version }}
           env:
@@ -155,7 +159,10 @@ spec:
           configMap:
             name: "kadalu-info"
         - name: glusterfsd-mountdir
-{%- if brick_device == "" %}
+{%- if pvc_name != "" %}
+          persistentVolumeClaim:
+            claimName: {{ pvc_name }}
+{%- elif host_brick_path != "" %}
           hostPath:
             path: "{{ host_brick_path }}"
             type: Directory


### PR DESCRIPTION
Work-In-Progress

For this, one needs to provide PVC name as argument in storage config, something like below.

```
---
apiVersion: kadalu-operator.storage/v1alpha1
kind: KadaluStorage
metadata:
 # This will be used as name of PV Hosting Volume
  name: storage-pool-1
spec:
  type: Replica1
  storage:
    - pvc: pvc-from-other-csi

```

TODO: Considering this gets deployed on 'any' node where CSI is available, need to see
how to get node details back into client volfile.

Updates: #46