### PR TITLE
Kadalu external storage

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -254,6 +254,14 @@ def create_subdir_volume(hostvol_mnt, volname, size):
             ))
             break
 
+        if count >= 10:
+            logging.warn(logf(
+                "Waited for some time, Quota set failed, continuing.",
+                volsize=volsize,
+                num_tries=count
+            ))
+            break
+
         time.sleep(1)
 
     return Volume(
@@ -554,5 +562,4 @@ def check_external_volume(pv_request):
         hvol=hvol
     ))
 
-    unmount_volume(mntdir)
     return hvol

--- a/examples/sample-external-kadalu-storage.yaml
+++ b/examples/sample-external-kadalu-storage.yaml
@@ -1,0 +1,45 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kadalu.external.test  # Keep changing the name for different volumes
+provisioner: kadalu
+parameters:
+  hostvol_type: "External-Kadalu"
+  gluster_host: gluster1.kadalu.io   # Change to your gluster host
+  gluster_volname: kadalu            # Change to existing gluster volume
+  gluster_options: log-level=DEBUG   # Comma separated options
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv-ext-kadalu
+spec:
+  storageClassName: kadalu.external.test
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 150Mi # This needs to be set using 'kadalu-quotad'
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-ext-kadalu
+  labels:
+    app: sample-app
+spec:
+  containers:
+  - name: sample-app
+    image: docker.io/kadalu/sample-pv-check-app:latest
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - mountPath: "/mnt/pv"
+      name: csivol
+  volumes:
+  - name: csivol
+    persistentVolumeClaim:
+      claimName: pv-ext-kadalu
+  restartPolicy: OnFailure

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -214,7 +214,9 @@ test_kadalu)
 
     get_pvc_and_check examples/sample-test-app3.yaml "Replica3" 2 200
 
-    get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 40
+    get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 50
+
+    get_pvc_and_check examples/sample-external-kadalu-storage.yaml "External (Kadalu)" 1 50
 
 
     # Log everything so we are sure if things are as expected


### PR DESCRIPTION
The logic is simple. External volume details are passed as part of
storage-class itself. Instead of applying filters to find the hosting
volume, if the host-vol type passed is 'External-Kadalu' in storageclass,
we use the same volume for creating subvols.

Ideally, we could have better control if PVC request can have these
details, but the dynamic options are not allowed with PVC, but are
part of StorageClass.

But this is good enought to get the external storage in action for
kadalu users.

Check `examples/sample-external-kadalu-storage.yaml` for getting the
idea.

Updates #36