### PR TITLE
Running server/operator/csi processes as PID != 1

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -17,9 +17,12 @@ COPY csi/identityserver.py     /kadalu/
 COPY csi/main.py               /kadalu/
 COPY csi/nodeserver.py         /kadalu/
 COPY csi/volumeutils.py        /kadalu/
+COPY lib/startup.sh            /kadalu/startup.sh
 
 COPY templates/Replica1.client.vol.j2 /kadalu/templates/
 COPY templates/Replica3.client.vol.j2 /kadalu/templates/
+
+RUN chmod +x /kadalu/startup.sh
 
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
@@ -34,7 +37,7 @@ LABEL vcs-url="https://github.com/kadalu/kadalu"
 LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
-ENTRYPOINT ["/usr/bin/python3", "/kadalu/main.py"]
+ENTRYPOINT ["/kadalu/startup.sh", "/usr/bin/python3", "/kadalu/main.py"]
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/lib/startup.sh
+++ b/lib/startup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -x
+
+pid=0
+cmd=$1
+script=$2
+
+
+# SIGTERM-handler
+term_handler() {
+    if [ $pid -ne 0 ]; then
+        kill -SIGTERM "$pid"
+        wait "$pid"
+    fi
+    exit 143; # 128 + 15 -- SIGTERM
+}
+
+
+trap 'kill ${!}; term_handler' SIGTERM
+
+$cmd $script &
+pid="$!"
+
+# wait forever
+while true
+do
+    tail -f /dev/null & wait ${!}
+done

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -21,6 +21,9 @@ COPY templates/storageclass.yaml.j2  /kadalu/templates/storageclass.yaml.j2
 COPY templates/external-storageclass.yaml.j2  /kadalu/templates/external-storageclass.yaml.j2
 COPY lib/kadalulib.py                /kadalu/kadalulib.py
 COPY operator/main.py                /kadalu/
+COPY lib/startup.sh                  /kadalu/startup.sh
+
+RUN chmod +x /kadalu/startup.sh
 
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
@@ -35,7 +38,7 @@ LABEL vcs-url="https://github.com/kadalu/kadalu"
 LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
-ENTRYPOINT ["/usr/bin/python3", "/kadalu/main.py"]
+ENTRYPOINT ["/kadalu/startup.sh", "/usr/bin/python3", "/kadalu/main.py"]
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,6 +14,8 @@ COPY server/glusterfsd.py    /kadalu/glusterfsd.py
 COPY server/quotad.py        /kadalu/quotad.py
 COPY server/shd.py           /kadalu/shd.py
 COPY server/mount-glustervol /usr/bin/mount-glustervol
+COPY lib/startup.sh          /kadalu/startup.sh
+COPY server/stop-server.sh   /kadalu/stop-server.sh
 
 RUN mkdir -p /kadalu/templates /kadalu/volfiles
 
@@ -27,6 +29,8 @@ COPY templates/Replica3.brick2.vol.j2 /kadalu/templates/
 COPY templates/Replica3.shd.vol.j2    /kadalu/templates/
 
 RUN chmod +x /usr/bin/mount-glustervol
+RUN chmod +x /kadalu/startup.sh
+RUN chmod +x /kadalu/stop-server.sh
 
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
@@ -41,7 +45,7 @@ LABEL vcs-url="https://github.com/kadalu/kadalu"
 LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
-ENTRYPOINT ["/usr/bin/python3", "/kadalu/server.py"]
+ENTRYPOINT ["/kadalu/startup.sh", "/usr/bin/python3", "/kadalu/server.py"]
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/server/stop-server.sh
+++ b/server/stop-server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+volname=$1
+
+kill -SIGTERM $(cat /var/run/gluster/glusterfsd-bricks-${volname}-data-brick.pid)
+umount /bricks/${volname}/data

--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -39,6 +39,10 @@ spec:
       containers:
         - name: glusterfsd
           image: docker.io/{{ docker_user }}/kadalu-server:{{ kadalu_version }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/kadalu/stop-server.sh", "{{ volname }}"]
           # livenessProbe:
           #   exec:
           #     command:


### PR DESCRIPTION
- Introduced a startup script which runs as PID 1 in containers.
  This provides better signals Trapping inside container.
- Bidirectional mount was used between glusterfsd and quotad containers.
  Manual Unmount is required before stopping. Otherwise Kubernetes will
  leave the pod in Terminating state. PreStop script is introduced to send
  SIGTERM to glusterfsd process and unmount the brick.

Fixes: #96
Signed-off-by: Aravinda VK <mail@aravindavk.in>