### PR TITLE
Makefile changes to Pypi packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ templates/*.yaml
 manifests/*.vol
 __pycache__
 cli/kubectl_kadalu.egg-info
+cli/VERSION
+cli/LICENSE
+server/VERSION
+server/LICENSE
+server/kadalu_quotad/kadalulib.py*
+server/kadalu_quotad.egg-info

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,21 @@ prepare-release:
 		$(MAKE) build-containers
 endif
 
+pypi-build:
+	echo ${KADALU_VERSION} > cli/VERSION
+	cd cli; rm -rf dist; python3 setup.py sdist;
+	@cp lib/kadalulib.py server/kadalu_quotad/
+	echo ${KADALU_VERSION} > server/VERSION
+	cd server; rm -rf dist; python3 setup.py sdist;
+
+pypi-upload: pypi-build
+	cd cli; twine upload --username kadalu dist/*
+	cd server; twine upload --username kadalu dist/*
+
 ifeq ($(KADALU_VERSION), latest)
 release: prepare-release
 else
-release: prepare-release
+release: prepare-release pypi-upload
 	docker push ${DOCKER_USER}/kadalu-operator:${KADALU_VERSION}
 	docker push ${DOCKER_USER}/kadalu-csi:${KADALU_VERSION}
 	docker push ${DOCKER_USER}/kadalu-server:${KADALU_VERSION}

--- a/cli/MANIFEST.in
+++ b/cli/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md VERSION ../LICENSE
+recursive-include kubectl_kadalu *.py

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,9 +1,13 @@
 from setuptools import setup
 
+def version():
+    with open("VERSION") as version_file:
+        return version_file.read().strip()
+
 
 setup(
     name="kubectl-kadalu",
-    version="0.1.0",
+    version=version(),
     packages=["kubectl_kadalu"],
     include_package_data=True,
     install_requires=["PyYAML"],

--- a/doc/release-management.md
+++ b/doc/release-management.md
@@ -5,12 +5,12 @@
    Containers for a specific version(and latest). Built Containers
    will be published to dockerhub.
 
-        KADALU_VERSION=0.1.0 make release
+        TWINE_PASSWORD=<secret> KADALU_VERSION=0.4.0 make release
 
    **Note**: If `DOCKER_USER` is specified then it will publish the built
    Containers to respective Dockerhub account.
 
-        DOCKER_USER=aravindavk KADALU_VERSION=0.1.0 make release
+        DOCKER_USER=aravindavk KADALU_VERSION=0.4.0 make release
 
 3. Send the PR with manifest file and CHANGELOG.md file changes
 4. Create a new Github release - [https://github.com/kadalu/kadalu/releases/new](https://github.com/kadalu/kadalu/releases/new). In the

--- a/server/MANIFEST.in
+++ b/server/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md VERSION ../LICENSE
+recursive-include kadalu_quotad *.py

--- a/server/README.md
+++ b/server/README.md
@@ -4,5 +4,5 @@ Kadalu Server component, which runs glusterfsd and quotad.
 
 ## kadalu's QuotaD
 
-This is a script which runs as a container (when kadalu is running in native mode), so that the required size is set as Quota for the PV directory. If kadalu uses external gluster storage, then this needs to be installed with `pip3 install kadalu_quotad`, and run on the machine which is exporting storage. If there are 3 nodes exporting storage (ie, hosting gluster bricks), then this needs to be running on all the 3 nodes.
+This is a script which runs as a container (when kadalu is running in native mode), so that the required size is set as Quota for the PV directory. If kadalu uses external gluster storage, then this needs to be installed with `pip3 install kadalu-quotad`, and run on the machine which is exporting storage. If there are 3 nodes exporting storage (ie, hosting gluster bricks), then this needs to be running on all the 3 nodes.
 

--- a/server/kadalu_quotad/kadalulib.py
+++ b/server/kadalu_quotad/kadalulib.py
@@ -1,1 +1,0 @@
-../../lib/kadalulib.py

--- a/server/kadalu_quotad/quotad.py
+++ b/server/kadalu_quotad/quotad.py
@@ -6,7 +6,7 @@ import time
 import json
 import logging
 
-from kadalulib import execute, logf, CommandException, \
+from .kadalulib import execute, logf, CommandException, \
     get_volname_hash, get_volume_path, PV_TYPE_SUBVOL
 
 # Config file for kadalu info
@@ -124,8 +124,8 @@ def start():
     """
     first_time = True
     while True:
-        brick_path = os.environ["BRICK_PATH"]
-        if brick_path:
+        brick_path = os.environ.get("BRICK_PATH", None)
+        if brick_path is not None:
             crawl(brick_path)
         try:
             with open(CONFIG_FILE) as f:

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,15 +1,20 @@
 from setuptools import setup
 
 
+def version():
+    with open("VERSION") as version_file:
+        return version_file.read().strip()
+
+
 setup(
-    name="kadalu_quotad",
-    version="0.1.0",
+    name="kadalu-quotad",
+    version=version(),
     packages=["kadalu_quotad"],
     include_package_data=True,
-    install_requires=[""],
+    install_requires=["requests", "xxhash"],
     entry_points={
         "console_scripts": [
-            "kadalu_quotad = quotad.start:main"
+            "kadalu-quotad = kadalu_quotad.quotad:start"
         ]
     },
     platforms="linux",


### PR DESCRIPTION
`pip3 install twine` is required to upload to Pypi repository.

Along with the release,

```
$ export TWINE_PASSWORD=<secret>
$ KADALU_VERSION=0.4.0 make release
```

Only upload to pypi,

```
$ export TWINE_PASSWORD=<secret>
$ KADALU_VERSION=0.4.0 make pypi-upload
```

Signed-off-by: Aravinda VK <mail@aravindavk.in>