### PR TITLE
cli/kubectl_kadalu: add 'install' subcommand

### DIFF
--- a/cli/kubectl_kadalu/install.py
+++ b/cli/kubectl_kadalu/install.py
@@ -1,0 +1,55 @@
+import os
+import yaml
+import subprocess
+import tempfile
+import sys
+
+
+KUBECTL_CMD = "kubectl"
+
+
+def install_args(subparsers):
+    parser_install = subparsers.add_parser('install')
+    parser_install.add_argument(
+        "--version",
+        help="Kadalu Version to Install [default: latest]",
+        choices=["0.4.0", "latest"],
+        default="latest"
+    )
+    parser_install.add_argument(
+        "--type",
+        help="Type of installation - k8s/openshift [default: kubernetes]",
+        choices=["openshift", "kubernetes"],
+        default="kubernetes"
+    )
+    return
+
+
+def subcmd_install(args):
+    file_url = "https://raw.githubusercontent.com/kadalu/kadalu/master/manifests"
+    version = ""
+    insttype = ""
+
+    if args.version and args.version != "latest":
+        version = "-%s" % args.version
+
+    if args.type and args.type == "openshift":
+        insttype = "-openshift"
+
+    operator_file = "%s/kadalu-operator%s%s.yaml" % (file_url, insttype, version)
+
+    try:
+        cmd = [KUBECTL_CMD, "apply", "-f", operator_file]
+        resp = subprocess.run(cmd, capture_output=True, check=True,
+                              universal_newlines=True)
+        print("Kadalu operator create request sent successfully")
+        print(resp.stdout)
+        print()
+    except subprocess.CalledProcessError as err:
+        print("Error while running the following command", file=sys.stderr)
+        print("$ " + " ".join(cmd), file=sys.stderr)
+        print("", file=sys.stderr)
+        print(err.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    return

--- a/cli/kubectl_kadalu/main.py
+++ b/cli/kubectl_kadalu/main.py
@@ -3,12 +3,16 @@ from argparse import ArgumentParser
 from kubectl_kadalu.storage_add import storage_add_args, subcmd_storage_add, \
     storage_add_validation
 
+from kubectl_kadalu.install import install_args, subcmd_install
+
 
 def get_args():
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(dest="mode")
 
     storage_add_args(subparsers)
+
+    install_args(subparsers)
 
     return parser.parse_args()
 


### PR DESCRIPTION
With `install` subcommand, this CLI package now becomes
one tool to install and add storage for kadalu operator.

Invoking it is as simple as `kubectl kadalu install` and
it takes an optional argument of `--version`, which by
default takes latest yaml.

Fixes: #114