### PR TITLE
Add deletion of CSIDriver

### DIFF
--- a/extras/scripts/cleanup
+++ b/extras/scripts/cleanup
@@ -20,4 +20,7 @@ kubectl delete -nkadalu ServiceAccount kadalu-operator
 kubectl delete -nkadalu ClusterRoleBinding kadalu-operator
 kubectl delete -nkadalu Deployment kadalu-operator
 
+# CSIDriver
+kubectl delete CSIDriver org.kadalu.gluster
+
 kubectl delete namespace kadalu


### PR DESCRIPTION
Based on the feedback yesterday, it might make sense to add the deletion of the CSIDriver to the cleanup script