### PR TITLE
travis: ignore few checks in pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
   include:
     - name: pylint tests
       script:
+        - pip install requests xxhash grpcio pyxattr kubernetes
         - make pylint || travis_terminate 1;
     - name: kadalu with kube 1.15.0
       script:

--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,18 @@ pylint:
 	@cp lib/kadalulib.py server/
 	@cp lib/kadalulib.py operator/
 	@cp server/kadalu_quotad/quotad.py server/
-	-pylint --disable=W0511 -s n lib/kadalulib.py
-	-pylint --disable=W0511 -s n server/glusterfsd.py
-	-pylint --disable=W0511 -s n server/quotad.py
-	-pylint --disable=W0511 -s n server/server.py
-	-pylint --disable=W0511 -s n server/shd.py
-	-pylint --disable=W0511 -s n csi/controllerserver.py
-	-pylint --disable=W0511 -s n csi/identityserver.py
-	-pylint --disable=W0511 -s n csi/main.py
-	-pylint --disable=W0511 -s n csi/nodeserver.py
-	-pylint --disable=W0511 -s n csi/volumeutils.py
-	-pylint --disable=W0511 -s n operator/main.py
-	-pylint --disable=W0511 -s n extras/scripts/gen_manifest.py
+	@pylint --disable=W0511 -s n lib/kadalulib.py
+	@pylint --disable=W0511 -s n server/glusterfsd.py
+	@pylint --disable=W0511 -s n server/quotad.py
+	@pylint --disable=W0511 -s n server/server.py
+	@pylint --disable=W0511 -s n server/shd.py
+	@pylint --disable=W0511 -s n csi/controllerserver.py
+	@pylint --disable=W0511 -s n csi/identityserver.py
+	@pylint --disable=W0511 -s n csi/main.py
+	@pylint --disable=W0511 -s n csi/nodeserver.py
+	@pylint --disable=W0511 -s n csi/volumeutils.py
+	@pylint --disable=W0511 -s n operator/main.py
+	@pylint --disable=W0511 -s n extras/scripts/gen_manifest.py
 	@rm csi/kadalulib.py
 	@rm server/kadalulib.py
 	@rm operator/kadalulib.py


### PR DESCRIPTION
few checks disabled (E0401, E1101):
  * server/glusterfsd.py:34:8: E1101: Module 'xattr' has no 'set' member (no-member)
  * server/glusterfsd.py:35:14: E1101: Module 'xattr' has no 'get' member (no-member)
  * csi/main.py:9:0: E0401: Unable to import 'grpc' (import-error)

Make the test fail in case of warning and errors.

Updates: #63