### PR TITLE
Fix Python crash due to missing `capture_output` arg

### DIFF
--- a/cli/kubectl_kadalu/install.py
+++ b/cli/kubectl_kadalu/install.py
@@ -1,11 +1,9 @@
 import os
 import yaml
-import subprocess
 import tempfile
 import sys
 
-
-KUBECTL_CMD = "kubectl"
+from kubectl_kadalu import utils
 
 
 def install_args(subparsers):
@@ -39,13 +37,12 @@ def subcmd_install(args):
     operator_file = "%s/kadalu-operator%s%s.yaml" % (file_url, insttype, version)
 
     try:
-        cmd = [KUBECTL_CMD, "apply", "-f", operator_file]
-        resp = subprocess.run(cmd, capture_output=True, check=True,
-                              universal_newlines=True)
+        cmd = [utils.KUBECTL_CMD, "apply", "-f", operator_file]
+        resp = utils.execute(cmd)
         print("Kadalu operator create request sent successfully")
         print(resp.stdout)
         print()
-    except subprocess.CalledProcessError as err:
+    except utils.CommandError as err:
         print("Error while running the following command", file=sys.stderr)
         print("$ " + " ".join(cmd), file=sys.stderr)
         print("", file=sys.stderr)

--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -1,11 +1,9 @@
 import os
 import yaml
-import subprocess
 import tempfile
 import sys
 
-
-KUBECTL_CMD = "kubectl"
+from kubectl_kadalu import utils
 
 
 def storage_add_args(subparsers):
@@ -124,16 +122,15 @@ def subcmd_storage_add(args):
         with os.fdopen(fd, 'w') as tmp:
             yaml.dump(data, tmp)
 
-        cmd = [KUBECTL_CMD, "create", "-f", tempfile_path]
-        resp = subprocess.run(cmd, capture_output=True, check=True,
-                              universal_newlines=True)
+        cmd = [utils.KUBECTL_CMD, "create", "-f", tempfile_path]
+        resp = utils.execute(cmd)
         print("Storage add request sent successfully")
         print(resp.stdout)
         print()
         print("Storage Yaml file for your reference:")
         print(yaml.dump(data))
         print()
-    except subprocess.CalledProcessError as err:
+    except utils.CommandError as err:
         print("Error while running the following command", file=sys.stderr)
         print("$ " + " ".join(cmd), file=sys.stderr)
         print("", file=sys.stderr)

--- a/cli/kubectl_kadalu/utils.py
+++ b/cli/kubectl_kadalu/utils.py
@@ -1,0 +1,31 @@
+import subprocess
+
+KUBECTL_CMD = "kubectl"
+
+
+class CmdResponse:
+    def __init__(self, rc, out, err):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = err
+
+
+class CommandError(Exception):
+    def __init__(self, rc, err):
+        super().__init__("error %d %s" % (rc, err))
+        self.returncode = rc
+        self.stderr = err
+
+
+def execute(cmd):
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+    out, err = proc.communicate()
+    if proc.returncode == 0:
+        return CmdResponse(proc.returncode, out, err)
+
+    raise CommandError(proc.returncode, err)


### PR DESCRIPTION
`capture_output` argument is introduced in Python 3.7, which is
not yet available in many distributions.

With this PR, command execution method is changed to not use
`subprocess.run` command but use `subprocess.Popen` and `communicate`

Fixes: #138
Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>