### PR TITLE
replica3: add 'read-hash-mode 5' option

### DIFF
--- a/templates/Replica3.client.vol.j2
+++ b/templates/Replica3.client.vol.j2
@@ -132,7 +132,7 @@ volume {{ volname }}-replicate-0
     option entry-change-log on
     option metadata-change-log on
     option halo-min-replicas 2
-    option read-hash-mode 1
+    option read-hash-mode 5
     option locking-scheme full
     option metadata-splitbrain-forced-heal off
     option shd-max-threads 1

--- a/templates/Replica3.shd.vol.j2
+++ b/templates/Replica3.shd.vol.j2
@@ -132,7 +132,7 @@ volume {{ volname }}-replicate-0
     option entry-change-log on
     option metadata-change-log on
     option halo-min-replicas 2
-    option read-hash-mode 1
+    option read-hash-mode 5
     option locking-scheme full
     option metadata-splitbrain-forced-heal off
     option shd-max-threads 1


### PR DESCRIPTION
From the documentation of read-hash mode in glusterfs (afr.c):

```
inode-read fops happen only on one of the bricks in replicate. AFR will
prefer the one computed using the method specified using this option.

0 = first readable child of AFR, starting from 1st child.
1 = hash by GFID of file (all clients use same subvolume)
2 = hash by GFID of file and client PID.
3 = brick having the least outstanding read requests.
4 = brick having the least network ping latency.
5 = Hybrid mode between 3 and 4, ie least value among
    network-latency multiplied by outstanding-read-requests.

```

Fixes: #53