### PR TITLE
extras/tie-breaker: fix the starting errors

### DIFF
--- a/extras/tie-breaker/Dockerfile
+++ b/extras/tie-breaker/Dockerfile
@@ -20,7 +20,7 @@ LABEL vcs-url="https://github.com/kadalu/kadalu"
 LABEL vendor="org.kadalu.gluster"
 LABEL version="${version}"
 
-ENTRYPOINT ["glusterfsd", "-f", "/kadalu/thin-arbiter.vol", "-l", "/dev/stdout", "-N"]
+ENTRYPOINT ["bash", "-c", "mkdir -p /mnt/brick/.glusterfs && glusterfsd -f /kadalu/thin-arbiter.vol -l /dev/stdout -N"]
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/extras/tie-breaker/thin-arbiter.vol
+++ b/extras/tie-breaker/thin-arbiter.vol
@@ -37,7 +37,7 @@ volume /mnt/brick
     type debug/io-stats
     option count-fop-hits off
     option latency-measurement off
-    option unique-id /mnt/brick/
+    option unique-id /mnt/brick
     subvolumes ta-index
 end-volume
 
@@ -53,5 +53,5 @@ volume ta-server
     option auth-path /mnt/brick
     option transport.address-family inet
     option transport-type tcp
-    subvolumes /mnt
+    subvolumes /mnt/brick
 end-volume


### PR DESCRIPTION
With this patch, once the images are pused to docker.io, we can get
thin-arbiter running on any machine like below:

`docker run --privileged -p 24007:24007 -v ${hostbrickdir}:/mnt/brick docker.io/kadalu/kadalu-tiebreaker:latest`

We expect this to be the easiest way of running a thin-arbiter on
any machine for our users, along with other apps too.

Updates: #37