### PR TITLE
tiebreaker: provide option to take port value too

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -182,12 +182,14 @@ def storage_add_data(args):
                 }
             )
 
+    # TODO: Support for different port can be added later
     if args.tiebreaker:
         for tb_data in args.tiebreaker:
             node, path = tb_data.split(":")
             content["spec"]["tiebreaker"] = {
                 "node": node,
-                "path": path
+                "path": path,
+                "port": 24007
             }
 
     return content

--- a/operator/main.py
+++ b/operator/main.py
@@ -210,8 +210,11 @@ def update_config_map(core_v1_client, obj):
             # Add default tiebreaker if no tie-breaker option provided
             tiebreaker = {
                 "node": "tie-breaker.kadalu.io",
-                "path": "/mnt"
+                "path": "/mnt",
             }
+        if not tiebreaker.get("port", None):
+            tiebreaker["port"] = 24007
+
         data["tiebreaker"] = tiebreaker
 
     volinfo_file = "%s.info" % volname

--- a/templates/Replica2.client.vol.j2
+++ b/templates/Replica2.client.vol.j2
@@ -76,6 +76,7 @@ volume {{ volume_id }}-ta
     option transport-type socket
     option transport.listen-backlog 1024
     option remote-host {{ tiebreaker["node"] }}
+    option remote-port {{ tiebreaker["port"] }}
     option remote-subvolume {{ tiebreaker["path"] }}
     option transport.socket.keepalive-count 9
     option transport.socket.own-thread off

--- a/templates/Replica2.shd.vol.j2
+++ b/templates/Replica2.shd.vol.j2
@@ -76,6 +76,7 @@ volume {{ volume_id }}-ta
     option transport-type socket
     option transport.listen-backlog 1024
     option remote-host {{ tiebreaker["node"] }}
+    option remote-port {{ tiebreaker["port"] }}
     option remote-subvolume {{ tiebreaker["path"] }}
     option transport.socket.keepalive-count 9
     option transport.socket.own-thread off


### PR DESCRIPTION
This patch brings closure to the basic feature. With this patch, user has an option to use different ports too for tiebreaker node.

Currently not allowed in CLI. We can improve the CLI only if users start asking for the feature, and this is a good place for people to do their first contributions.