### PR TITLE
Liveness and Readiness probe for Glusterfsd container

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -13,8 +13,8 @@ import csi_pb2_grpc
 from volumeutils import mount_and_select_hosting_volume, \
     create_virtblock_volume, create_subdir_volume, delete_volume, \
     get_pv_hosting_volumes, PV_TYPE_SUBVOL, PV_TYPE_VIRTBLOCK, \
-    HOSTVOL_MOUNTDIR, check_external_volume, unmount_volume, \
-    update_free_size
+    HOSTVOL_MOUNTDIR, check_external_volume, \
+    update_free_size, unmount_glusterfs
 from kadalulib import logf, send_analytics_tracker
 
 VOLINFO_DIR = "/var/lib/gluster"
@@ -80,7 +80,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
 
                 if not filters.get('kadalu-format', None):
                     # No need to keep the mount on controller
-                    unmount_volume(mntdir)
+                    unmount_glusterfs(mntdir)
                     logging.info(logf(
                         "Volume (External) created",
                         name=request.name,

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -22,7 +22,7 @@ class TimeoutOSError(OSError):
     pass  # noqa # pylint: disable=unnecessary-pass
 
 
-def retry_errors(func, args, errors, timeout=120, interval=2):
+def retry_errors(func, args, errors, timeout=130, interval=2):
     """Retries given function in case of specified errors"""
     starttime = int(time.time())
 
@@ -40,6 +40,22 @@ def retry_errors(func, args, errors, timeout=120, interval=2):
 
             # Reraise the same error
             raise
+
+
+def is_gluster_mount_proc_running(volname):
+    """
+    Check if glusterfs process is running for the given Volume name
+    to confirm Glusterfs process is mounted
+    """
+    cmd = (
+        r'ps ax | grep -w "/usr/sbin/glusterfs" '
+        r'| grep -q "\-\-volfile\-id %s"' % volname
+    )
+
+    proc = subprocess.Popen(cmd, shell=True, stderr=None,
+                            stdout=None, universal_newlines=True)
+    proc.communicate()
+    return proc.returncode == 0
 
 
 def makedirs(dirpath):

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -232,7 +232,7 @@ spec:
           args:
             - "--provisioner=kadalu"
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
+            - "--connection-timeout=3m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -43,12 +43,16 @@ spec:
             preStop:
               exec:
                 command: ["/kadalu/stop-server.sh", "{{ volname }}"]
-          # livenessProbe:
-          #   exec:
-          #     command:
-          #       - /usr/bin/ps -ef | grep glusterfsd
-          #   initialDelaySeconds: 120
-          #   periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 24007
+            initialDelaySeconds: 120
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 24007
+            initialDelaySeconds: 120
+            periodSeconds: 20
           env:
 {%- if kube_hostname != "" %}
             - name: HOSTNAME


### PR DESCRIPTION
Added Liveness and Readiness probe to see glusterfsd
container is started and port 24007 is ready to use.

Also check Glusterfs mounted or not using `ps -ax | grep glusterfs`
instead of using `os.path.ismount` command.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>