### PR TITLE
csi: make sure we never overwrite

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -207,6 +207,14 @@ def create_virtblock_volume(hostvol_mnt, volname, size):
         path=os.path.dirname(volpath)
     ))
 
+    if os.path.exists(volpath_full):
+        rand = time.time()
+        logging.info(logf(
+            "Getting 'Create request' on existing file, renaming.",
+            path=volpath_full, random=rand
+        ))
+        os.rename(volpath_full, "%s.%s" % (volpath_full, rand))
+
     volpath_fd = os.open(volpath_full, os.O_CREAT | os.O_RDWR)
     os.close(volpath_fd)
     os.truncate(volpath_full, size)


### PR DESCRIPTION
There are reports of possible PV create request repeat,
which gets error like below:

```
b'mkfs.xfs: /mnt/snowstorm/virtblock/ed/d3/pvc-7e309eed-7654-4aee-a014-a3c48b712756 appears to contain an existing filesystem (xfs).
```

This patch tries to make sure we will never have a case where there would be PV which is already created being created as volume again.