### PR TITLE
Fixing the broken URL reported by user

### DIFF
--- a/doc/try-kadalu.md
+++ b/doc/try-kadalu.md
@@ -129,4 +129,4 @@ As long as glusterfs promises to keep the backend layout same, and continue to p
 
 ### Gluster and Kadalu
 
-We have compiled a list of things [here](./gluster-and-kadalu.md)
+We have compiled a list of things [here](https://kadalu.io/docs/k8s-storage/master/gluster-and-kadalu)


### PR DESCRIPTION
Added full listed URL for https://kadalu.io/docs/k8s-storage/master/gluster-and-kadalu. Addresses https://github.com/kadalu/kadalu/issues/219