### PR TITLE
Improvement to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ env:
     - GO_METALINTER_THREADS=1
     - GO_COVER_DIR=_output
     - VM_DRIVER=none
-    - MINIKUBE_VERSION=v1.5.2
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
 
@@ -53,13 +52,14 @@ jobs:
           ## Pass CLI as an argument, so we can test CLI
         - tests/travis-test.sh v1.15.0 cli || travis_terminate 1;
         - tests/cleanup.sh v1.15.0 || travis_terminate 1;
-    - name: kadalu with kube 1.16.0
+    - name: kadalu with kube 1.18.2
       script:
+        - sudo apt install -y conntrack
         - make build-containers || travis_terminate 1;
         - make gen-manifest || travis_terminate 1;
-        - tests/setup.sh v1.16.0 || travis_terminate 1;
-        - tests/travis-test.sh v1.16.0 || travis_terminate 1;
-        - tests/cleanup.sh v1.16.0 || travis_terminate 1;
+        - tests/setup.sh v1.18.2 || travis_terminate 1;
+        - tests/travis-test.sh v1.18.2 || travis_terminate 1;
+        - tests/cleanup.sh v1.18.2 || travis_terminate 1;
     - name: kadalu with kube 1.13.7
       script:
         - make build-containers || travis_terminate 1;

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 DOCKER_USER?=kadalu
 KADALU_VERSION?=latest
-
+KADALU_LATEST?=latest
 
 help:
 	@echo "    make build-grpc        - To generate grpc Python Code"
@@ -102,13 +102,13 @@ ifeq ($(KADALU_VERSION), latest)
 release: prepare-release
 else
 release: prepare-release pypi-upload
-	docker tag ${DOCKER_USER}/kadalu-operator:${KADALU_VERSION} ${DOCKER_USER}/kadalu-operator:latest
-	docker tag ${DOCKER_USER}/kadalu-csi:${KADALU_VERSION} ${DOCKER_USER}/kadalu-csi:latest
-	docker tag ${DOCKER_USER}/kadalu-server:${KADALU_VERSION} ${DOCKER_USER}/kadalu-server:latest
+	docker tag ${DOCKER_USER}/kadalu-operator:${KADALU_VERSION} ${DOCKER_USER}/kadalu-operator:${KADALU_LATEST}
+	docker tag ${DOCKER_USER}/kadalu-csi:${KADALU_VERSION} ${DOCKER_USER}/kadalu-csi:${KADALU_LATEST}
+	docker tag ${DOCKER_USER}/kadalu-server:${KADALU_VERSION} ${DOCKER_USER}/kadalu-server:${KADALU_LATEST}
 	docker push ${DOCKER_USER}/kadalu-operator:${KADALU_VERSION}
 	docker push ${DOCKER_USER}/kadalu-csi:${KADALU_VERSION}
 	docker push ${DOCKER_USER}/kadalu-server:${KADALU_VERSION}
-	docker push ${DOCKER_USER}/kadalu-operator:latest
-	docker push ${DOCKER_USER}/kadalu-csi:latest
-	docker push ${DOCKER_USER}/kadalu-server:latest
+	docker push ${DOCKER_USER}/kadalu-operator:${KADALU_LATEST}
+	docker push ${DOCKER_USER}/kadalu-csi:${KADALU_LATEST}
+	docker push ${DOCKER_USER}/kadalu-server:${KADALU_LATEST}
 endif

--- a/operator/Dockerfile.base
+++ b/operator/Dockerfile.base
@@ -5,9 +5,6 @@ RUN yum -y install procps-ng xfsprogs net-tools telnet wget e2fsprogs python3-pi
 RUN yum clean all -y
 RUN rm -rf /var/cache/yum
 
-RUN wget -P /etc/yum.repos.d \
-    https://download.gluster.org/pub/gluster/glusterfs/LATEST/Fedora/glusterfs-fedora.repo
-
 # Install Python GRPC library and copy all CSI related files
 RUN python3 -m pip install jinja2 xxhash requests datetime \
      prometheus_client

--- a/tests/kubectl_kadalu_tests.sh
+++ b/tests/kubectl_kadalu_tests.sh
@@ -4,6 +4,8 @@ DISK="$1"
 
 # This test assumes a kubernetes setup available with host as minikube
 
+HOSTNAME="$2"
+
 function install_cli_package() {
     apt install python3-pip
     python3 -m pip install setuptools
@@ -27,18 +29,18 @@ function test_storage_add() {
     kubectl create -f tests/get-minikube-pvc.yaml
 
     sleep 1
-    kubectl kadalu storage-add test-volume3 --type Replica3 --device minikube:/mnt/${DISK}/file3.1 --path minikube:/mnt/${DISK}/dir3.2 --pvc local-pvc || return 1
+    kubectl kadalu storage-add test-volume3 --type Replica3 --device ${HOSTNAME}:/mnt/${DISK}/file3.1 --path ${HOSTNAME}:/mnt/${DISK}/dir3.2 --pvc local-pvc || return 1
 
     # Test Replica2 option
-    kubectl kadalu storage-add test-volume2 --type Replica2 --device minikube:/mnt/${DISK}/file2.1 --device minikube:/mnt/${DISK}/file2.2 || return 1
+    kubectl kadalu storage-add test-volume2 --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.1 --device ${HOSTNAME}:/mnt/${DISK}/file2.2 || return 1
 
     # Test Replica2 with tie-breaker option
     sudo truncate -s 2g /mnt/${DISK}/file2.{10,20}
 
-    kubectl kadalu storage-add test-volume2-1 --type Replica2 --device minikube:/mnt/${DISK}/file2.10 --device minikube:/mnt/${DISK}/file2.20 --tiebreaker tie-breaker.kadalu.io:/mnt || return 1
+    kubectl kadalu storage-add test-volume2-1 --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.10 --device ${HOSTNAME}:/mnt/${DISK}/file2.20 --tiebreaker tie-breaker.kadalu.io:/mnt || return 1
 
     # Check if the type default is Replica1
-    kubectl kadalu storage-add test-volume1 --device minikube:/mnt/${DISK}/file1 || return 1
+    kubectl kadalu storage-add test-volume1 --device ${HOSTNAME}:/mnt/${DISK}/file1 || return 1
 
     # Check for external storage
     # TODO: (For now, keep the name as 'ext-config' as PVC should use this

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -14,7 +14,7 @@ function wait_till_pods_start() {
 	    echo "Successful after $cnt seconds"
 	    break
 	fi
-	if [[ $cnt -eq 100 ]]; then
+	if [[ $cnt -eq 200 ]]; then
 	    kubectl get pods -o wide
 	    echo "giving up after 200 seconds"
 	    fail=1
@@ -218,8 +218,13 @@ kadalu_operator)
 
     sleep 1
     # Start storage
+    output=$(kubectl get nodes -o=name)
+    # output will be in format 'node/hostname'. We need 'hostname'
+    HOSTNAME=$(basename $output)
+    echo "Hostname is ${HOSTNAME}"
     cp tests/storage-add.yaml /tmp/kadalu-storage.yaml
     sed -i -e "s/DISK/${DISK}/g" /tmp/kadalu-storage.yaml
+    sed -i -e "s/node: minikube/node: ${HOSTNAME}/g" /tmp/kadalu-storage.yaml
 
     # Prepare PVC also as a storage
     sed -i -e "s/DISK/${DISK}/g" tests/get-minikube-pvc.yaml
@@ -264,7 +269,11 @@ test_kadalu)
     ;;
 
 cli_tests)
-    bash tests/kubectl_kadalu_tests.sh "$DISK"
+    output=$(kubectl get nodes -o=name)    
+    # output will be in format 'node/hostname'. We need 'hostname'
+    HOSTNAME=$(basename $output)
+    echo "Hostname is ${HOSTNAME}"
+    bash tests/kubectl_kadalu_tests.sh "$DISK" "${HOSTNAME}"
     wait_till_pods_start
     ;;
 


### PR DESCRIPTION
* base-image: fedora31 has latest glusterfs by default
* travis: install conntrack (required for 1.18.x onwards)
* tests: add a job for 1.18.2 version (remove 1.16.x)
* tests: add hostname instead of 'minikube'
* change minikube version to 1.7.2 (latest is 1.9.2)

Signed-off-by: Amar Tumballi <amar@kadalu.io>