### PR TITLE
Node affinity added to Storage filter

### DIFF
--- a/operator/main.py
+++ b/operator/main.py
@@ -200,6 +200,7 @@ def update_config_map(core_v1_client, obj):
     for idx, storage in enumerate(bricks):
         data["bricks"].append({
             "brick_path": "/bricks/%s/data/brick" % volname,
+            "kube_hostname": storage.get("node", ""),
             "node": get_brick_hostname(volname,
                                        storage.get("node", "pvc"),
                                        idx),


### PR DESCRIPTION
This new filter is to support Local PV usecase. If multiple
Replica 1 storage pools available in cluster then create a
Storage class for required node affinity. If a PV is claimed
based on this storage class then it behaves just like Local storage
but with dynamic provisioning.

Example storage class:

```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: kadalu.replica1.node1
provisioner: kadalu
parameters:
  node_affinity: "node1"  # As shown in `kubectl get nodes`
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>