### PR TITLE
Use numeric identifier for each storage pod

### DIFF
--- a/operator/main.py
+++ b/operator/main.py
@@ -153,22 +153,19 @@ def get_brick_device_dir(brick):
     return brick_device_dir
 
 
-def get_brick_hostname(volname, node, idx, suffix=True):
+def get_brick_hostname(volname, idx, suffix=True):
     """Brick hostname is <statefulset-name>-<ordinal>.<service-name>
     statefulset name is the one which is visible when the
     `get pods` command is run, so the format used for that name
-    is "server-<volname>-<idx>-<hostname>". Escape dots from the
+    is "server-<volname>-<idx>". Escape dots from the
     hostname from the input otherwise will become invalid name.
     Service is created with name as Volume name. For example,
-    brick_hostname will be "server-spool1-0-minikube-0.spool1" and
-    server pod name will be "server-spool1-0-minikube"
+    brick_hostname will be "server-spool1-0-0.spool1" and
+    server pod name will be "server-spool1-0"
     """
     tmp_vol = volname.replace("-", "_")
-    tmp_node = node.replace("-", "_")
     dns_friendly_volname = re.sub(r'\W+', '', tmp_vol).replace("_", "-")
-    dns_friendly_nodename = re.sub(r'\W+', '', tmp_node).replace("_", "-")
-    hostname = "server-%s-%s-%d" % (dns_friendly_volname,
-                                    dns_friendly_nodename, idx)
+    hostname = "server-%s-%d" % (dns_friendly_volname, idx)
     if suffix:
         return "%s-0.%s" % (hostname, volname)
 
@@ -201,9 +198,7 @@ def update_config_map(core_v1_client, obj):
         data["bricks"].append({
             "brick_path": "/bricks/%s/data/brick" % volname,
             "kube_hostname": storage.get("node", ""),
-            "node": get_brick_hostname(volname,
-                                       storage.get("node", "pvc"),
-                                       idx),
+            "node": get_brick_hostname(volname, idx),
             "node_id": storage["node_id"],
             "host_brick_path": storage.get("path", ""),
             "brick_device": storage.get("device", ""),
@@ -268,7 +263,6 @@ def deploy_server_pods(obj):
         # TODO: Understand the need, and usage of suffix
         template_args["serverpod_name"] = get_brick_hostname(
             volname,
-            storage.get("node", "pvc"),
             idx,
             suffix=False
         )

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -9,13 +9,13 @@ function wait_till_pods_start() {
     while true; do
 	cnt=$((cnt + 1))
 	sleep 2
-	ret=$(kubectl get pods -nkadalu | grep 'Running' | wc -l)
+	ret=$(kubectl get pods -nkadalu -o wide | grep 'Running' | wc -l)
 	if [[ $ret -ge 9 ]]; then
 	    echo "Successful after $cnt seconds"
 	    break
 	fi
 	if [[ $cnt -eq 100 ]]; then
-	    kubectl get pods
+	    kubectl get pods -o wide
 	    echo "giving up after 200 seconds"
 	    fail=1
 	    break
@@ -26,7 +26,7 @@ function wait_till_pods_start() {
     done
 
     kubectl get sc
-    kubectl get pods -nkadalu
+    kubectl get pods -nkadalu -o wide
     # Return failure if fail variable is set to 1
     if [ $fail -eq 1 ]; then
 	echo "Marking the test as 'FAIL'"
@@ -53,15 +53,15 @@ function get_pvc_and_check() {
     while true; do
 	cnt=$((cnt + 1))
 	sleep 1
-	ret=$(kubectl get pods | grep 'Completed' | wc -l)
+	ret=$(kubectl get pods -o wide | grep 'Completed' | wc -l)
 	if [[ $ret -eq ${pod_count} ]]; then
 	    echo "Successful after $cnt seconds"
 	    break
 	fi
 	if [[ $cnt -eq ${time_limit} ]]; then
 	    kubectl get pvc
-	    kubectl get pods -nkadalu
-	    kubectl get pods
+	    kubectl get pods -nkadalu -o wide
+	    kubectl get pods -o wide
 	    echo "exiting after ${time_limit} seconds"
 	    result=1
 	    fail=1
@@ -72,7 +72,7 @@ function get_pvc_and_check() {
 	fi
     done
     kubectl get pvc
-    kubectl get pods
+    kubectl get pods -o wide
 
     #Delete the pods/pvc
     for p in $(kubectl get pods -o name); do


### PR DESCRIPTION
Removed hostname from the Server Pod name. Use
`kubectl get pods -n kadalu -o wide` to see node
name where that pod is running

Fixes: #185
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>