### PR TITLE
Fixed an issue while deleting the PV directory in underlying volume

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -7,6 +7,7 @@ import json
 import time
 import logging
 import threading
+import shutil
 from errno import ENOTCONN
 
 from jinja2 import Template
@@ -424,7 +425,7 @@ def delete_volume(volname):
     volpath = os.path.join(HOSTVOL_MOUNTDIR, vol.hostvol, vol.volpath)
     try:
         if vol.voltype == PV_TYPE_SUBVOL:
-            os.removedirs(volpath)
+            shutil.rmtree(volpath)
         else:
             os.remove(volpath)
     except OSError as err:


### PR DESCRIPTION
`os.removedirs` is for deleting the leaf directory and parent
empty dirs till root. But in this case, recursive removal of
pv directory is required.

`shutil.rmtree` is used instead of `os.removedirs`

Fixes: #248
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>