### PR TITLE
Microk8s support

### DIFF
--- a/cli/kubectl_kadalu/install.py
+++ b/cli/kubectl_kadalu/install.py
@@ -20,7 +20,7 @@ def install_args(subparsers):
     parser_install.add_argument(
         "--type",
         help="Type of installation - k8s/openshift [default: kubernetes]",
-        choices=["openshift", "kubernetes"],
+        choices=["openshift", "kubernetes", "microk8s"],
         default="kubernetes"
     )
     parser_install.add_argument(

--- a/extras/scripts/gen_manifest.py
+++ b/extras/scripts/gen_manifest.py
@@ -29,12 +29,17 @@ def template(filename, template_file=None, template_args=None):
 if __name__ == "__main__":
     DOCKER_USER = os.environ.get("DOCKER_USER", "kadalu")
     KADALU_VERSION = os.environ.get("KADALU_VERSION", "latest")
-    OPENSHIFT = bool(int(os.environ.get("OPENSHIFT", 0)))
+    K8S_DIST = os.environ.get("K8S_DIST", "kubernetes")
+    KUBELET_DIR = "/var/lib/kubelet"
+    if K8S_DIST == "microk8s":
+        KUBELET_DIR = "/var/snap/microk8s/common/var/lib/kubelet"
+
     TEMPLATE_ARGS = {
         "namespace": "kadalu",
         "kadalu_version": KADALU_VERSION,
         "docker_user": DOCKER_USER,
-        "openshift": OPENSHIFT
+        "k8s_dist": K8S_DIST,
+        "kubelet_dir": KUBELET_DIR
     }
 
     template(sys.argv[1], template_file="operator.yaml.j2", template_args=TEMPLATE_ARGS)

--- a/manifests/kadalu-operator-0.7.0.yaml
+++ b/manifests/kadalu-operator-0.7.0.yaml
@@ -143,7 +143,7 @@ rules:
     verbs: ["create", "list", "watch", "delete"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["get", "create", "delete", "patch"]
@@ -205,3 +205,7 @@ spec:
               value: "kadalu"
             - name: KADALU_VERSION
               value: "0.7.0"
+            - name: KUBELET_DIR
+              value: "/var/lib/kubelet"
+            - name: K8S_DIST
+              value: "kubernetes"

--- a/manifests/kadalu-operator-master.yaml
+++ b/manifests/kadalu-operator-master.yaml
@@ -35,38 +35,6 @@ metadata:
 
 
 ---
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-metadata:
-  name: kadalu-scc
-allowPrivilegedContainer: true
-allowHostNetwork: true
-allowHostDirVolumePlugin: true
-priority:
-allowedCapabilities: ['*']
-allowHostPorts: true
-allowHostPID: true
-allowHostIPC: true
-readOnlyRootFilesystem: false
-requiredDropCapabilities: []
-defaultAddCapabilities: []
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-fsGroup:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-volumes: ['*']
-users:
-  - system:serviceaccount:kadalu:kadalu-server-sa
-  - system:serviceaccount:kadalu:kadalu-operator-sa
-  - system:serviceaccount:kadalu:kadalu-csi-provisioner-sa
-  - system:serviceaccount:kadalu:kadalu-csi-nodeplugin-sa
-
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -220,7 +188,7 @@ spec:
           securityContext:
             capabilities: {}
             privileged: true
-          image: docker.io/kadalu/kadalu-operator:0.7.0
+          image: docker.io/kadalu/kadalu-operator:master
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -236,8 +204,8 @@ spec:
             - name: DOCKER_USER
               value: "kadalu"
             - name: KADALU_VERSION
-              value: "0.7.0"
+              value: "master"
             - name: KUBELET_DIR
               value: "/var/lib/kubelet"
             - name: K8S_DIST
-              value: "openshift"
+              value: "kubernetes"

--- a/manifests/kadalu-operator-microk8s-master.yaml
+++ b/manifests/kadalu-operator-microk8s-master.yaml
@@ -35,38 +35,6 @@ metadata:
 
 
 ---
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-metadata:
-  name: kadalu-scc
-allowPrivilegedContainer: true
-allowHostNetwork: true
-allowHostDirVolumePlugin: true
-priority:
-allowedCapabilities: ['*']
-allowHostPorts: true
-allowHostPID: true
-allowHostIPC: true
-readOnlyRootFilesystem: false
-requiredDropCapabilities: []
-defaultAddCapabilities: []
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-fsGroup:
-  type: RunAsAny
-supplementalGroups:
-  type: RunAsAny
-volumes: ['*']
-users:
-  - system:serviceaccount:kadalu:kadalu-server-sa
-  - system:serviceaccount:kadalu:kadalu-operator-sa
-  - system:serviceaccount:kadalu:kadalu-csi-provisioner-sa
-  - system:serviceaccount:kadalu:kadalu-csi-nodeplugin-sa
-
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -220,7 +188,7 @@ spec:
           securityContext:
             capabilities: {}
             privileged: true
-          image: docker.io/kadalu/kadalu-operator:0.7.0
+          image: docker.io/kadalu/kadalu-operator:master
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -236,8 +204,8 @@ spec:
             - name: DOCKER_USER
               value: "kadalu"
             - name: KADALU_VERSION
-              value: "0.7.0"
+              value: "master"
             - name: KUBELET_DIR
-              value: "/var/lib/kubelet"
+              value: "/var/snap/microk8s/common/var/lib/kubelet"
             - name: K8S_DIST
-              value: "openshift"
+              value: "microk8s"

--- a/manifests/kadalu-operator-openshift-master.yaml
+++ b/manifests/kadalu-operator-openshift-master.yaml
@@ -220,7 +220,7 @@ spec:
           securityContext:
             capabilities: {}
             privileged: true
-          image: docker.io/kadalu/kadalu-operator:0.7.0
+          image: docker.io/kadalu/kadalu-operator:master
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -236,7 +236,7 @@ spec:
             - name: DOCKER_USER
               value: "kadalu"
             - name: KADALU_VERSION
-              value: "0.7.0"
+              value: "master"
             - name: KUBELET_DIR
               value: "/var/lib/kubelet"
             - name: K8S_DIST

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -175,7 +175,7 @@ rules:
     verbs: ["create", "list", "watch", "delete"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["get", "create", "delete", "patch"]
@@ -237,3 +237,7 @@ spec:
               value: "kadalu"
             - name: KADALU_VERSION
               value: "0.7.0"
+            - name: KUBELET_DIR
+              value: "/var/lib/kubelet"
+            - name: K8S_DIST
+              value: "openshift"

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -143,7 +143,7 @@ rules:
     verbs: ["create", "list", "watch", "delete"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["get", "create", "delete", "patch"]
@@ -205,3 +205,7 @@ spec:
               value: "kadalu"
             - name: KADALU_VERSION
               value: "0.7.0"
+            - name: KUBELET_DIR
+              value: "/var/lib/kubelet"
+            - name: K8S_DIST
+              value: "kubernetes"

--- a/operator/main.py
+++ b/operator/main.py
@@ -17,6 +17,8 @@ from kadalulib import execute, logging_setup, logf, send_analytics_tracker
 
 NAMESPACE = os.environ.get("KADALU_NAMESPACE", "kadalu")
 VERSION = os.environ.get("KADALU_VERSION", "latest")
+K8S_DIST = os.environ.get("K8S_DIST", "kubernetes")
+KUBELET_DIR = os.environ.get("KUBELET_DIR")
 MANIFESTS_DIR = "/kadalu/templates"
 KUBECTL_CMD = "/usr/bin/kubectl"
 KADALU_CONFIG_MAP = "kadalu-info"
@@ -272,6 +274,7 @@ def deploy_server_pods(obj):
         template_args["pvc_name"] = storage.get("pvc", "")
         template_args["brick_device_dir"] = get_brick_device_dir(storage)
         template_args["brick_node_id"] = storage["node_id"]
+        template_args["k8s_dist"] = K8S_DIST
 
         filename = os.path.join(MANIFESTS_DIR, "server.yaml")
         template(filename, **template_args)
@@ -452,7 +455,8 @@ def deploy_csi_pods(core_v1_client):
     filename = os.path.join(MANIFESTS_DIR, "csi.yaml")
     docker_user = os.environ.get("DOCKER_USER", "kadalu")
     template(filename, namespace=NAMESPACE, kadalu_version=VERSION,
-             docker_user=docker_user)
+             docker_user=docker_user, k8s_dist=K8S_DIST,
+             kubelet_dir=KUBELET_DIR)
     execute(KUBECTL_CMD, create_cmd, "-f", filename)
     logging.info(logf("Deployed CSI Pods", manifest=filename))
 

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -64,13 +64,15 @@ spec:
             - name: ADDRESS
               value: /plugin/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins_registry/kadalu/csi.sock
+              value: {{ kubelet_dir }}/plugins_registry/kadalu/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
@@ -92,11 +94,13 @@ spec:
               value: unix://plugin/csi.sock
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ kubelet_dir }}/pods
               mountPropagation: "Bidirectional"
             - name: glusterfsd-volfilesdir
               mountPath: "/var/lib/gluster"
@@ -114,15 +118,15 @@ spec:
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/kadalu
+            path: {{ kubelet_dir }}/plugins_registry/kadalu
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ kubelet_dir }}/pods
             type: Directory
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ kubelet_dir }}/plugins_registry/
             type: Directory
         - name: glusterfsd-volfilesdir
           configMap:
@@ -238,6 +242,8 @@ spec:
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -249,6 +255,10 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: KADALU_VERSION
+              value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -268,6 +278,8 @@ spec:
               value: unix://plugin/csi.sock
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -32,7 +32,7 @@ metadata:
   name: kadalu-server-sa
   namespace: {{ namespace }}
 
-{% if openshift %}
+{% if k8s_dist == "openshift" %}
 ---
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
@@ -174,7 +174,7 @@ rules:
     verbs: ["create", "list", "watch", "delete"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csidrivers"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["get", "create", "delete", "patch"]
@@ -236,3 +236,7 @@ spec:
               value: "{{ docker_user }}"
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: KUBELET_DIR
+              value: "{{ kubelet_dir }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"

--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -74,6 +74,8 @@ spec:
               value: "{{ brick_device }}"
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           securityContext:
             capabilities: {}
             privileged: true
@@ -123,6 +125,8 @@ spec:
               value: "{{ brick_device }}"
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           securityContext:
             capabilities: {}
             privileged: true
@@ -158,6 +162,8 @@ spec:
               value: "{{ brick_device }}"
             - name: KADALU_VERSION
               value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
           securityContext:
             capabilities: {}
             privileged: true

--- a/tests/kubectl_kadalu_tests.sh
+++ b/tests/kubectl_kadalu_tests.sh
@@ -18,10 +18,10 @@ function install_cli_package() {
 }
 
 function test_install() {
-    sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' manifests/kadalu-operator.yaml
+    sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' manifests/kadalu-operator-master.yaml
 
     echo "Installing Operator through CLI"
-    kubectl kadalu install --local-yaml manifests/kadalu-operator.yaml || return 1
+    kubectl kadalu install --local-yaml manifests/kadalu-operator-master.yaml || return 1
 }
 
 function test_storage_add() {

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -214,8 +214,8 @@ kadalu_operator)
     echo "Starting the kadalu Operator"
 
     # pick the operator file from repo
-    sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' manifests/kadalu-operator.yaml
-    kubectl create -f manifests/kadalu-operator.yaml
+    sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' manifests/kadalu-operator-master.yaml
+    kubectl create -f manifests/kadalu-operator-master.yaml
 
     sleep 1
     # Start storage


### PR DESCRIPTION
@marklester pointed out issue with microk8s due to different path
used for Kubelet directory.

- Added support for Kubelet dir
- `kubectl kadalu install` CLI enhanced to accept `--type=microk8s`
- Improved Makefile to handle these k8s distributions
- Added K8S_DIST env variable to all pods(Operator, CSI and Server)

Fixes: #239
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>