### PR TITLE
change the csi images to a multiarch image

### DIFF
--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: kadalu-csi-nodeplugin-sa
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          image: docker.io/raspbernetes/csi-node-driver-registrar:latest
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -232,7 +232,7 @@ spec:
       serviceAccountName: kadalu-csi-provisioner-sa
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: docker.io/raspbernetes/csi-external-provisioner:latest
           args:
             - "--provisioner=kadalu"
             - "--csi-address=$(ADDRESS)"
@@ -248,7 +248,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: docker.io/raspbernetes/csi-external-attacher:latest
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
When I checked about best method to support storage on arm,
Michael Fornaro (from kubernetes slack) pointed at
https://github.com/raspbernetes/multi-arch-images

Signed-off-by: Amar Tumballi <amar@kadalu.io>