### PR TITLE
Fix the changes in operator yaml file

### DIFF
--- a/manifests/kadalu-operator-devel.yaml
+++ b/manifests/kadalu-operator-devel.yaml
@@ -75,6 +75,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator-microk8s-devel.yaml
+++ b/manifests/kadalu-operator-microk8s-devel.yaml
@@ -75,6 +75,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator-openshift-devel.yaml
+++ b/manifests/kadalu-operator-openshift-devel.yaml
@@ -107,6 +107,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -107,6 +107,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator-rke-devel.yaml
+++ b/manifests/kadalu-operator-rke-devel.yaml
@@ -75,6 +75,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -75,6 +75,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -75,6 +75,7 @@ rules:
     resources:
       - storageclasses
       - volumeattachments
+      - volumeattachments/status
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups:
       - rbac.authorization.k8s.io


### PR DESCRIPTION
When we make changes to 'templates/operator.yaml.j2' we should be committing the changes after 'make gen-manifest'. Correcting the previous error now.

Fixes: #295
Signed-off-by: Amar Tumballi <amar@kadalu.io>