### PR TITLE
across: use kubectl apply, instead of create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ gen-manifest:
 	@mkdir -p manifests
 	@DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} \
 		python3 extras/scripts/gen_manifest.py manifests/kadalu-operator${SUFFIX}.yaml
-	@echo "kubectl create -f manifests/kadalu-operator${SUFFIX}.yaml"
+	@echo "kubectl apply -f manifests/kadalu-operator${SUFFIX}.yaml"
 	@DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} \
 		K8S_DIST=openshift                                   \
 		python3 extras/scripts/gen_manifest.py manifests/kadalu-operator-openshift${SUFFIX}.yaml
@@ -48,7 +48,7 @@ gen-manifest:
 	@echo "In the case of MicroK8s, deploy Kadalu Operator by running "
 	@echo "the following command"
 	@echo
-	@echo "kubectl create -f manifests/kadalu-operator-microk8s${SUFFIX}.yaml"
+	@echo "kubectl apply -f manifests/kadalu-operator-microk8s${SUFFIX}.yaml"
 
 	@DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} \
 		K8S_DIST=rke                                    \
@@ -57,7 +57,7 @@ gen-manifest:
 	@echo "In the case of Rancher (RKE), deploy Kadalu Operator by running "
 	@echo "the following command"
 	@echo
-	@echo "kubectl create -f manifests/kadalu-operator-rke${SUFFIX}.yaml"
+	@echo "kubectl apply -f manifests/kadalu-operator-rke${SUFFIX}.yaml"
 
 pylint:
 	@cp lib/kadalulib.py csi/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [CONTRIBUTING](CONTRIBUTING.md)
 
 The release versions and 'latest' versions are not yet ARM ready! But we have an image for `linux/arm64` platform support!
 
-Start the operator with `kubectl create -f https://raw.githubusercontent.com/kadalu/kadalu/devel/manifests/kadalu-operator-devel.yaml` to get started! Once we have few users confirming it works, will tag it in a release!
+Start the operator with `kubectl apply -f https://raw.githubusercontent.com/kadalu/kadalu/devel/manifests/kadalu-operator-devel.yaml` to get started! Once we have few users confirming it works, will tag it in a release!
 
 
 ## NOTE

--- a/doc/csi-to-claim-persistent-volumes.md
+++ b/doc/csi-to-claim-persistent-volumes.md
@@ -20,7 +20,7 @@ spec:
 ```
 
 ```console
-$ kubectl create -f ./sample-pvc.yaml
+$ kubectl apply -f ./sample-pvc.yaml
 persistentvolumeclaim/pv1 created
 ```
 
@@ -60,7 +60,7 @@ spec:
 ```
 
 ```console
-$ kubectl create -f ./sample-app.yaml
+$ kubectl apply -f ./sample-app.yaml
 pod1 created
 ```
 

--- a/doc/external-gluster-storage.md
+++ b/doc/external-gluster-storage.md
@@ -112,7 +112,7 @@ spec:
 
 Please edit 'gluster_host' and 'gluster_volname' parameters in Storage Class.
 
-Then run `kubectl create -f ./external-gluster-as-pv.yaml`
+Then run `kubectl apply -f ./external-gluster-as-pv.yaml`
 
 Note that in this mode, there would be as many 'StorageClass' as number of PVs, but
 that is not avoidable at present because we can't pass user driven input from PV claim

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -79,7 +79,7 @@ spec:
 Create PVC using,
 
 ```console
-$ kubectl create -f sample-pvc.yaml
+$ kubectl apply -f sample-pvc.yaml
 persistentvolumeclaim/pv1 created
 ```
 
@@ -118,6 +118,6 @@ spec:
 ```
 
 ```console
-$ kubectl create -f sample-app.yaml
+$ kubectl apply -f sample-app.yaml
 pod1 created
 ```

--- a/doc/release-management.md
+++ b/doc/release-management.md
@@ -20,4 +20,4 @@
 
    For example,
 
-        kubectl create -f https://raw.githubusercontent.com/kadalu/kadalu/devel/manifests/kadalu-operator-0.7.0.yaml
+        kubectl apply -f https://raw.githubusercontent.com/kadalu/kadalu/devel/manifests/kadalu-operator-0.7.0.yaml

--- a/doc/running-a-webserver.md
+++ b/doc/running-a-webserver.md
@@ -19,7 +19,7 @@ spec:
 ```
 
 ```console
-$ kubectl create -f webserver-pvc.yaml
+$ kubectl apply -f webserver-pvc.yaml
 persistentvolumeclaim/webapp-pv created
 ```
 
@@ -57,7 +57,7 @@ spec:
 ```
 
 ```console
-$ kubectl create -f webserver-app.yaml
+$ kubectl apply -f webserver-app.yaml
 pod/webapp created
 ```
 

--- a/doc/running-minio.md
+++ b/doc/running-minio.md
@@ -25,7 +25,7 @@ spec:
 Now deploy the Minio by running,
 
 ```console
-$ kubectl create -f minio-deployment.yaml
+$ kubectl apply -f minio-deployment.yaml
 persistentvolumeclaim/minio-pv-claim created
 deployment.extensions/minio-deployment created
 service/minio-service created

--- a/extras/scripts/run-local
+++ b/extras/scripts/run-local
@@ -25,7 +25,7 @@ which oc > /dev/null
 if [ $? -eq 0 ]; then
     oc create -f manifests/kadalu-operator-openshift.yaml
 else
-    kubectl create -f manifests/kadalu-operator.yaml
+    kubectl apply -f manifests/kadalu-operator.yaml
 fi
 
 

--- a/operator/main.py
+++ b/operator/main.py
@@ -456,6 +456,7 @@ def deploy_csi_pods(core_v1_client):
     template(filename, namespace=NAMESPACE, kadalu_version=VERSION,
              docker_user=docker_user, k8s_dist=K8S_DIST,
              kubelet_dir=KUBELET_DIR)
+
     execute(KUBECTL_CMD, CREATE_CMD, "-f", filename)
     logging.info(logf("Deployed CSI Pods", manifest=filename))
 
@@ -472,6 +473,7 @@ def deploy_config_map(core_v1_client):
                 "Found existing configmap. Updating",
                 name=item.metadata.name
             ))
+
             # Don't overwrite UID info.
             configmap_data = core_v1_client.read_namespaced_config_map(
                 KADALU_CONFIG_MAP, NAMESPACE)
@@ -485,6 +487,7 @@ def deploy_config_map(core_v1_client):
              namespace=NAMESPACE,
              kadalu_version=VERSION,
              uid=uid)
+
     execute(KUBECTL_CMD, CREATE_CMD, "-f", filename)
     logging.info(logf("Deployed ConfigMap", manifest=filename))
     return uid

--- a/tests/kubectl_kadalu_tests.sh
+++ b/tests/kubectl_kadalu_tests.sh
@@ -21,7 +21,7 @@ function test_install() {
 
 function test_storage_add() {
     sed -i -e "s/DISK/${DISK}/g" tests/get-minikube-pvc.yaml
-    kubectl create -f tests/get-minikube-pvc.yaml
+    kubectl apply -f tests/get-minikube-pvc.yaml
 
     sleep 1
     cli/build/kubectl-kadalu storage-add test-volume3 --script-mode --type Replica3 --device ${HOSTNAME}:/mnt/${DISK}/file3.1 --path ${HOSTNAME}:/mnt/${DISK}/dir3.2 --pvc local-pvc || return 1

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -48,7 +48,7 @@ function get_pvc_and_check() {
     time_limit=$4
 
     echo "Running sample test app ${log_text} yaml from repo "
-    kubectl create -f ${yaml_file}
+    kubectl apply -f ${yaml_file}
 
     cnt=0
     result=0
@@ -216,7 +216,7 @@ kadalu_operator)
 
     # pick the operator file from repo
     sed -i -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' manifests/kadalu-operator-devel.yaml
-    kubectl create -f manifests/kadalu-operator-devel.yaml
+    kubectl apply -f manifests/kadalu-operator-devel.yaml
 
     sleep 1
     # Start storage
@@ -230,10 +230,10 @@ kadalu_operator)
 
     # Prepare PVC also as a storage
     sed -i -e "s/DISK/${DISK}/g" tests/get-minikube-pvc.yaml
-    kubectl create -f tests/get-minikube-pvc.yaml
+    kubectl apply -f tests/get-minikube-pvc.yaml
 
     sleep 1
-    kubectl create -f /tmp/kadalu-storage.yaml
+    kubectl apply -f /tmp/kadalu-storage.yaml
 
     wait_till_pods_start
     ;;


### PR DESCRIPTION
If we create a pod (any instance) with kubectl 'create', we can't update it
with newer changes. It is good to use 'kubectl apply' inside the scripts.

Updates: #303
Signed-off-by: Amar Tumballi <amar@kadalu.io>