### PR TITLE
lib: remove google analytics tracking from project

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,3 @@ See [CONTRIBUTING](CONTRIBUTING.md)
 The release versions and 'latest' versions are not yet ARM ready! But we have an image for `linux/arm64` platform support!
 
 Start the operator with `kubectl apply -f https://raw.githubusercontent.com/kadalu/kadalu/devel/manifests/kadalu-operator-devel.yaml` to get started! Once we have few users confirming it works, will tag it in a release!
-
-
-## NOTE
-
-We are tracking the number of downloads based on 'docker pull' stats, and also
-through google analytics. [This Commit](https://github.com/kadalu/kadalu/commit/cbc83fd751bf0221e22b61bd6ebad4af40e38275) gives detail of what is added to code w.r.to tracking.

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -4,11 +4,9 @@ import subprocess
 import logging
 import sys
 import os
-from datetime import datetime
 import time
 import sqlite3
 
-import requests
 import xxhash
 
 CREATE_TABLE_1 = """CREATE TABLE IF NOT EXISTS summary (
@@ -159,25 +157,14 @@ def logging_setup():
 def send_analytics_tracker(name, uid=None):
     """Send setup events to Google analytics"""
 
-    if KADALU_VERSION == "canary":
-        return
+    # This function is not required anymore as we expect
+    # users to report usage through github issues, or by
+    # giving a 'star'.
+    # Only thing we learnt from this is, External, Replica3
+    # and Replica1 are preferred in that order (So far,
+    # as of Sept 2020)
 
-    ga_id = "UA-144588868-1" # Static string
-    reqheader = {'user-agent': 'Kadalu-App', 'accept': '*/*'}
-    url = "https://www.google-analytics.com/collect?v=1&t=pageview"
-    track_page = "http://kadalu.org/kadalu-%s-%s" % (
-        name, KADALU_VERSION)
-    track_title = "Kadalu %s" % name
-
-    if not uid:
-        uid = datetime.now().timestamp()
-    track_url = "%s&dl=%s&dt=%s&tid=%s&cid=%s" % (url, track_page, track_title, ga_id, uid)
-
-    try:
-        requests.get(track_url, headers=reqheader)
-    except:   # noqa # pylint: disable=bare-except
-        pass
-
+    return (name, uid)
 
 class SizeAccounting:
     """


### PR DESCRIPTION
We promised we would remove it before 1.0 release, and as we are nearing 0.8.0 version, it seems like a good time to do it. We trust in users to have good faith in liking the project if they find it interesting, useful.

Updates: #314
Signed-off-by: Amar Tumballi <amar@kadalu.io>