### PR TITLE
kubectl-kadalu: Support for k3s kubectl command

### DIFF
--- a/cli/kubectl_kadalu/install.py
+++ b/cli/kubectl_kadalu/install.py
@@ -54,7 +54,7 @@ def run(args):
         operator_file = "%s/kadalu-operator%s%s.yaml" % (file_url, insttype, version)
 
     try:
-        cmd = [args.kubectl_cmd, "apply", "-f", operator_file]
+        cmd = utils.kubectl_cmd(args) + ["apply", "-f", operator_file]
         print("Executing '%s'" % " ".join(cmd))
         if args.dry_run:
             return

--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -137,7 +137,7 @@ def get_kube_nodes(args):
     if args.dry_run:
         return []
 
-    cmd = [args.kubectl_cmd, "get", "nodes", "-ojson"]
+    cmd = utils.kubectl_cmd(args) + ["get", "nodes", "-ojson"]
     try:
         resp = utils.execute(cmd)
         data = json.loads(resp.stdout)
@@ -252,7 +252,7 @@ def run(args):
         with os.fdopen(config, 'w') as tmp:
             tmp.write(yaml_content)
 
-        cmd = [args.kubectl_cmd, "create", "-f", tempfile_path]
+        cmd = utils.kubectl_cmd(args) + ["create", "-f", tempfile_path]
         resp = utils.execute(cmd)
         print("Storage add request sent successfully")
         print(resp.stdout)

--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -193,8 +193,8 @@ def fetch_status(storages, args):
                  "select count(pvname), sum(size), min(size), "
                  "avg(size), max(size) from pv_stats")
 
-        cmd = [
-            args.kubectl_cmd, "exec", "-it",
+        cmd = utils.kubectl_cmd(args) + [
+            "exec", "-it",
             storage.storage_units[0].podname,
             "-c", "glusterfsd", "-nkadalu", "sqlite3",
             dbpath,
@@ -226,7 +226,7 @@ def fetch_status(storages, args):
 
 def run(args):
     """Shows List of Storages"""
-    cmd = [args.kubectl_cmd, "get", "configmap",
+    cmd = utils.kubectl_cmd(args) + ["get", "configmap",
            "kadalu-info", "-nkadalu", "-ojson"]
 
     try:

--- a/cli/kubectl_kadalu/utils.py
+++ b/cli/kubectl_kadalu/utils.py
@@ -69,3 +69,11 @@ def kubectl_cmd_help(cmd):
     print("Use `--kubectl-cmd` option if kubectl is installed "
           "in custom path", file=sys.stderr)
     sys.exit(1)
+
+
+def kubectl_cmd(args):
+    """k3s embeds kubectl into the k3s binary itself and
+    provides kubectl as subcommand. For example `k3s kubectl`.
+    Split the given command to support these types.
+    """
+    return args.kubectl_cmd.split()


### PR DESCRIPTION
k3s embeds the kubectl command and provides as subcommand. For
example to run `k3s kubectl get pods`.

All the kubectl-kadalu subcommands internally call `kubectl`
command to do the action. For example, `kubectl kadalu install`
will fetch the yaml file required and then calls `kubectl create -f <yaml>`

`--kubectl-cmd="k3s kubectl"` option now works properly while
using k3s. For example,

```
$ sudo k3s kubectl kadalu storage-list --kubectl-cmd="k3s kubectl"
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>