### PR TITLE
Fix the kubectl exec deprecated message

### DIFF
--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -196,7 +196,7 @@ def fetch_status(storages, args):
         cmd = utils.kubectl_cmd(args) + [
             "exec", "-it",
             storage.storage_units[0].podname,
-            "-c", "glusterfsd", "-nkadalu", "sqlite3",
+            "-c", "glusterfsd", "-nkadalu", "--", "sqlite3",
             dbpath,
             query
         ]


### PR DESCRIPTION
```
error 1 kubectl exec [POD] [COMMAND] is DEPRECATED and will be
removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
```

Updates: #321
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>