### PR TITLE
Downgrade the kubernetes python client

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -6,7 +6,8 @@ RUN curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s h
 RUN chmod +x /usr/bin/kubectl
 
 # Install Python GRPC library and copy all CSI related files
-RUN python3 -m pip install kubernetes
+RUN python3 -m pip install kubernetes==11.0.0
+
 RUN mkdir -p /kadalu/manifests
 
 COPY templates/services.yaml.j2      /kadalu/templates/services.yaml.j2


### PR DESCRIPTION
With `12.0.0`, Python client is failing to connect to K8s API
server. Downgrading to `11.0.0` till the issue is root caused.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>