### PR TITLE
operator: check for reachability of gluster external volume

### DIFF
--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -226,8 +226,7 @@ def fetch_status(storages, args):
 
 def run(args):
     """Shows List of Storages"""
-    cmd = utils.kubectl_cmd(args) + ["get", "configmap",
-           "kadalu-info", "-nkadalu", "-ojson"]
+    cmd = utils.kubectl_cmd(args) + ["get", "configmap", "kadalu-info", "-nkadalu", "-ojson"]
 
     try:
         resp = utils.execute(cmd)


### PR DESCRIPTION
This would help people to identify the reason for error quickly. One of the
common issue is, gluster host may be reachable from the host machines in the
cluster, but not from the pods.

Updates: #332
Signed-off-by: Amar Tumballi <amar@kadalu.io>