### PR TITLE
Automatic detection of bricks for quotad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
   include:
     - name: pylint tests
       script:
-        - pip install requests xxhash grpcio pyxattr kubernetes
+        - pip install requests xxhash grpcio pyxattr kubernetes glustercli
         - make pylint || travis_terminate 1;
     - name: kadalu with kube 1.15.0
       script:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ pylint:
 	@cp lib/kadalulib.py csi/
 	@cp lib/kadalulib.py server/
 	@cp lib/kadalulib.py operator/
-	@cp server/kadalu_quotad/quotad.py server/
+	@cp server/kadalu_quotad/quotad.py server/kadalu_quotad/glusterutils.py server/
 	@pylint --disable=W0511 -s n lib/kadalulib.py
 	@pylint --disable=W0511 -s n server/glusterfsd.py
 	@pylint --disable=W0511 -s n server/quotad.py
@@ -80,6 +80,7 @@ pylint:
 	@rm server/kadalulib.py
 	@rm operator/kadalulib.py
 	@rm server/quotad.py
+	@rm server/glusterutils.py
 	@cd cli && make gen-version
 	@cd cli/kubectl_kadalu && pylint --disable W0511 *.py
 

--- a/operator/Dockerfile.base
+++ b/operator/Dockerfile.base
@@ -10,7 +10,7 @@ RUN yum clean all -y
 RUN rm -rf /var/cache/yum
 
 # Install Python GRPC library and copy all CSI related files
-RUN python3 -m pip install jinja2 requests datetime xxhash
+RUN python3 -m pip install jinja2 requests datetime xxhash glustercli
 
 RUN mkdir -p /kadalu/
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,8 @@ RUN rpm -qa | grep gluster | tee /gluster-rpm-versions.txt
 COPY lib/kadalulib.py        /kadalu/kadalulib.py
 COPY server/server.py        /kadalu/server.py
 COPY server/glusterfsd.py    /kadalu/glusterfsd.py
-COPY server/kadalu_quotad/quotad.py   /kadalu/quotad.py
+COPY server/kadalu_quotad/quotad.py       /kadalu/quotad.py
+COPY server/kadalu_quotad/glusterutils.py /kadalu/glusterutils.py
 COPY server/shd.py           /kadalu/shd.py
 COPY server/mount-glustervol /usr/bin/mount-glustervol
 COPY lib/startup.sh          /kadalu/startup.sh

--- a/server/README.md
+++ b/server/README.md
@@ -14,6 +14,8 @@ In order for persistent volume claim resources.requests.storage limits to be enf
 * The XFS volumes must be mounted with the prjquota option.
 * For a single brick set the environment variable BRICK_PATH
 _**or**_
+* Set the environment variable BRICK_PATH=AUTO for automatic brick detection
+_**or**_
 * For one or more bricks list the bricks in /var/lib/glusterd/kadalu.info in the format expected by [quotad](kadalu_quotad/quotad.py)
 * Install kadalu-quotad with `pip3 install kadalu-quotad`, and run on the machine which is exporting storage. If there are 3 nodes exporting storage (ie, hosting gluster bricks), then this needs to be running on all the 3 nodes.
 

--- a/server/kadalu_quotad/glusterutils.py
+++ b/server/kadalu_quotad/glusterutils.py
@@ -1,0 +1,53 @@
+"""
+Utilities for reading information from gluster for 'external' quotad
+"""
+import os
+from glustercli.cli import volume
+
+KADALU_PATHS = {'info', 'subvol'}
+UUID_FILE = "/var/lib/glusterd/glusterd.info"
+
+myuuid = None
+
+
+def get_node_id():
+    """
+    Returns the local glusterd's UUID
+    """
+    global myuuid
+
+    if myuuid is not None:
+        return myuuid
+
+    val = None
+    with open(UUID_FILE) as uuid_file:
+        for line in uuid_file:
+            if line.startswith("UUID="):
+                val = line.strip().split("=")[-1]
+                break
+
+    myuuid = val
+    return val
+
+
+def get_automatic_bricks():
+    """
+    Returns array of paths to gluster bricks hosted on _this_ server
+    that appear to contain kadalu data and are therefore worth crawling
+    """
+    local_uuid = get_node_id()
+    found_bricks = []
+    for vol in volume.vollist():
+        for brick in volume.info(vol)[0]['bricks']:
+            if brick['uuid'] != local_uuid:
+                continue
+            brick_path = brick['name'].partition(':')[2]
+            is_kadalu_brick = True
+            for kadalu_path in KADALU_PATHS:
+                if not os.path.isdir(brick_path + '/' + kadalu_path):
+                    is_kadalu_brick = False
+                    break
+            if is_kadalu_brick:
+                found_bricks.append(brick_path)
+
+    return found_bricks

--- a/server/setup.py
+++ b/server/setup.py
@@ -11,7 +11,7 @@ setup(
     version=version(),
     packages=["kadalu_quotad"],
     include_package_data=True,
-    install_requires=["requests", "xxhash"],
+    install_requires=["glustercli", "requests", "xxhash"],
     entry_points={
         "console_scripts": [
             "kadalu-quotad = kadalu_quotad.quotad:start"


### PR DESCRIPTION
I'm lazy and can't be bothered with setting up a json file or
environment variable for my bricks.

In the event that quotad cannot find anything to crawl via these
mechanisms, this change causes quotad to query gluster for all
volumes and all bricks on those volumes, to discover any that are on
this machine. If the brick name and hostname for some reason don't
match, this won't work. It would be normal that they would match.

Then we check for the 'kadalu' signature on those bricks of an info
and subvol directory in the root. If that is the case, crawl those
bricks.

The search for bricksprocess is time consuming, and so we only perform
it once every 30 crawls (about once a minute). This is not
configurable, just as the quota check period isn't.