### PR TITLE
Include kubectl-kadalu in Operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 build-grpc:
 	python3 -m grpc_tools.protoc -I./csi/protos --python_out=csi --grpc_python_out=csi ./csi/protos/csi.proto
 
-build-containers:
+build-containers: cli-build
 	DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} bash build.sh
 
 SUFFIX?="-devel"

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -23,6 +23,7 @@ COPY templates/storageclass-kadalu.replica3.yaml.j2  /kadalu/templates/storagecl
 COPY templates/external-storageclass.yaml.j2  /kadalu/templates/external-storageclass.yaml.j2
 COPY lib/kadalulib.py                /kadalu/kadalulib.py
 COPY operator/main.py                /kadalu/
+COPY cli/build/kubectl-kadalu        /usr/bin/kubectl-kadalu
 COPY lib/startup.sh                  /kadalu/startup.sh
 
 RUN chmod +x /kadalu/startup.sh


### PR DESCRIPTION
- Kadalu Makefile changes:
Added cli-build dependency to build containers.

- Operator Dockerfile changes:
Copy cli/build/kubectl-kadalu to /usr/bin/kubectl-kadalu.

- cli/kubectl_kadalu/install.py changes:
Check if the operator exists, if yes exit with reason.

Fixes: #250 

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>