### PR TITLE
operator: handle 'modified' operation

### DIFF
--- a/tests/kubectl_kadalu_tests.sh
+++ b/tests/kubectl_kadalu_tests.sh
@@ -24,18 +24,18 @@ function test_storage_add() {
     kubectl apply -f tests/get-minikube-pvc.yaml
 
     sleep 1
-    cli/build/kubectl-kadalu storage-add test-volume3 --script-mode --type Replica3 --device ${HOSTNAME}:/mnt/${DISK}/file3.1 --path ${HOSTNAME}:/mnt/${DISK}/dir3.2 --pvc local-pvc || return 1
+    cli/build/kubectl-kadalu storage-add storage-pool-3 --script-mode --type Replica3 --device ${HOSTNAME}:/mnt/${DISK}/file3.1 --path ${HOSTNAME}:/mnt/${DISK}/dir3.2 --pvc local-pvc || return 1
 
     # Test Replica2 option
-    cli/build/kubectl-kadalu storage-add test-volume2 --script-mode --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.1 --device ${HOSTNAME}:/mnt/${DISK}/file2.2 || return 1
+    cli/build/kubectl-kadalu storage-add storage-pool-2 --script-mode --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.1 --device ${HOSTNAME}:/mnt/${DISK}/file2.2 || return 1
 
     # Test Replica2 with tie-breaker option
     sudo truncate -s 2g /mnt/${DISK}/file2.{10,20}
 
-    cli/build/kubectl-kadalu storage-add test-volume2-1 --script-mode --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.10 --device ${HOSTNAME}:/mnt/${DISK}/file2.20 --tiebreaker tie-breaker.kadalu.io:/mnt || return 1
+    cli/build/kubectl-kadalu storage-add storage-pool-2-1 --script-mode --type Replica2 --device ${HOSTNAME}:/mnt/${DISK}/file2.10 --device ${HOSTNAME}:/mnt/${DISK}/file2.20 --tiebreaker tie-breaker.kadalu.io:/mnt || return 1
 
     # Check if the type default is Replica1
-    cli/build/kubectl-kadalu storage-add test-volume1 --script-mode --device ${HOSTNAME}:/mnt/${DISK}/file1 || return 1
+    cli/build/kubectl-kadalu storage-add storage-pool-1 --script-mode --device ${HOSTNAME}:/mnt/${DISK}/file1 || return 1
 
     # Check for external storage
     # TODO: (For now, keep the name as 'ext-config' as PVC should use this

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -186,11 +186,12 @@ up)
     if [[ "${VM_DRIVER}" != "none" ]]; then
 	wait_for_ssh
 	# shellcheck disable=SC2086
-	minikube ssh "sudo mkdir -p /mnt/${DISK}; sudo truncate -s 4g /mnt/${DISK}/file{1,2.1,2.2,3.1}; sudo mkdir -p /mnt/${DISK}/{dir3.2,pvc}"
+	minikube ssh "sudo mkdir -p /mnt/${DISK}; sudo truncate -s 4g /mnt/${DISK}/file{1,2.1,2.2,3.1}; sudo mkdir -p /mnt/${DISK}/{dir3.2,dir3.2_modified,pvc}"
     else
 	sudo mkdir -p /mnt/${DISK}
 	sudo truncate -s 4g /mnt/${DISK}/file{1,2.1,2.2,3.1}
 	sudo mkdir -p /mnt/${DISK}/dir3.2
+	sudo mkdir -p /mnt/${DISK}/dir3.2_modified
 	sudo mkdir -p /mnt/${DISK}/pvc
     fi
 
@@ -248,6 +249,17 @@ test_kadalu)
     #get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 131
 
     get_pvc_and_check examples/sample-external-kadalu-storage.yaml "External (Kadalu)" 1 131
+
+    cp tests/storage-add.yaml /tmp/kadalu-storage.yaml
+    sed -i -e "s/DISK/${DISK}/g" /tmp/kadalu-storage.yaml
+    sed -i -e "s/node: minikube/node: ${HOSTNAME}/g" /tmp/kadalu-storage.yaml
+    sed -i -e "s/dir3.2/dir3.2_modified/g" /tmp/kadalu-storage.yaml
+    kubectl apply -f /tmp/kadalu-storage.yaml
+
+    sleep 5;
+    wait_till_pods_start
+
+    echo "After modification"
 
     #get_pvc_and_check examples/sample-test-app2.yaml "Replica2" 2 191
 


### PR DESCRIPTION
With this, users can do a 'replace-brick' like operation for their replica3 or replica2 volume.

Notice that, for `Replica1` and `External` type, it wouldn't be supported, as it doesn't make sense.

Updates: #330
Signed-off-by: Amar Tumballi <amar@kadalu.io>