### PR TITLE
images: move the glustercli to server image (from base image)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           buildx-version: latest
           qemu-version: latest
+      - name: Set up Python (for cli-build)
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Get the CLI build (kubectl-kadalu)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          KADALU_VERSION=devel make cli-build
       -
         name: Run Buildx
         if: success()

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -41,6 +41,15 @@ jobs:
         with:
           buildx-version: latest
           qemu-version: latest
+      - name: Set up Python (for cli-build)
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Get the CLI build (kubectl-kadalu)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          KADALU_VERSION=${{ env.kadalu_version }} make cli-build
       -
         name: Run Buildx
         if: success()

--- a/operator/Dockerfile.base
+++ b/operator/Dockerfile.base
@@ -10,7 +10,7 @@ RUN yum clean all -y
 RUN rm -rf /var/cache/yum
 
 # Install Python GRPC library and copy all CSI related files
-RUN python3 -m pip install jinja2 requests datetime xxhash glustercli
+RUN python3 -m pip install jinja2 requests datetime xxhash
 
 RUN mkdir -p /kadalu/
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,8 @@ FROM kadalu/kadalu-base
 RUN yum -y install python3-pyxattr glusterfs-server
 RUN rpm -qa | grep gluster | tee /gluster-rpm-versions.txt
 
+RUN python3 -m pip install glustercli || true && echo "External storage Quota feature may not work"
+
 COPY lib/kadalulib.py        /kadalu/kadalulib.py
 COPY server/server.py        /kadalu/server.py
 COPY server/glusterfsd.py    /kadalu/glusterfsd.py

--- a/server/kadalu_quotad/glusterutils.py
+++ b/server/kadalu_quotad/glusterutils.py
@@ -2,13 +2,17 @@
 Utilities for reading information from gluster for 'external' quotad
 """
 import os
-from glustercli.cli import volume
+import importlib
+try:
+    from glustercli.cli import volume
+except ImportError:
+    volume = None
+    pass
 
 KADALU_PATHS = {'info', 'subvol'}
 UUID_FILE = "/var/lib/glusterd/glusterd.info"
 
 myuuid = None
-
 
 def get_node_id():
     """
@@ -35,6 +39,9 @@ def get_automatic_bricks():
     Returns array of paths to gluster bricks hosted on _this_ server
     that appear to contain kadalu data and are therefore worth crawling
     """
+    if not volume:
+        return []
+
     local_uuid = get_node_id()
     found_bricks = []
     for vol in volume.vollist():

--- a/server/setup.py
+++ b/server/setup.py
@@ -11,7 +11,10 @@ setup(
     version=version(),
     packages=["kadalu_quotad"],
     include_package_data=True,
-    install_requires=["glustercli", "requests", "xxhash"],
+    install_requires=["requests", "xxhash"],
+    extras_require={
+        "gluster": ["glustercli"]
+    },
     entry_points={
         "console_scripts": [
             "kadalu-quotad = kadalu_quotad.quotad:start"


### PR DESCRIPTION
Server image already has major dependency w.r.to `glusterfs-server`
installed, and it makes sense that way.

Also make sure we have 'cli-build' done in scripts before building
images so `kubectl-kadalu` can be ready to be installed.

Also fix the other build failures due to `cli-build` dependency in operator image.

Fixes: #344
Signed-off-by: Amar Tumballi <amar@kadalu.io>