### PR TITLE
operator: Implement handle_deleted()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ pylint:
 	@cp lib/kadalulib.py csi/
 	@cp lib/kadalulib.py server/
 	@cp lib/kadalulib.py operator/
+	@cp cli/kubectl_kadalu/utils.py operator/
+	@cp cli/kubectl_kadalu/storage_list.py operator/
 	@cp server/kadalu_quotad/quotad.py server/kadalu_quotad/glusterutils.py server/
 	@pylint --disable=W0511 -s n lib/kadalulib.py
 	@pylint --disable=W0511 -s n server/glusterfsd.py
@@ -76,9 +78,13 @@ pylint:
 	@pylint --disable=W0511 -s n csi/volumeutils.py
 	@pylint --disable=W0511 -s n operator/main.py
 	@pylint --disable=W0511 -s n extras/scripts/gen_manifest.py
+	@pylint --disable=R0902 -s n cli/kubectl_kadalu/storage_list.py
+	@pylint --disable=R0902 -s n cli/kubectl_kadalu/utils.py
 	@rm csi/kadalulib.py
 	@rm server/kadalulib.py
 	@rm operator/kadalulib.py
+	@rm operator/utils.py
+	@rm operator/storage_list.py
 	@rm server/quotad.py
 	@rm server/glusterutils.py
 	@cd cli && make gen-version

--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -7,7 +7,7 @@ import sys
 
 import utils
 
-
+# noqa # pylint: disable=too-many-instance-attributes
 # noqa # pylint: disable=useless-object-inheritance
 # noqa # pylint: disable=too-few-public-methods
 # noqa # pylint: disable=bad-option-value
@@ -19,8 +19,10 @@ class StorageUnit(object):
         self.path = None
         self.device = None
         self.pvc = None
+        self.node = None
+        self.node_id = None
+        self.brick_device_dir = None
 
-# noqa # pylint: disable=too-many-instance-attributes
 class Storage(object):
     """Structure for Storage"""
     def __init__(self):
@@ -76,6 +78,9 @@ def list_storages(cmd_out, _args):
                 storage_unit.path = brick["host_brick_path"]
                 storage_unit.device = brick["brick_device"]
                 storage_unit.pvc = brick["pvc_name"]
+                storage_unit.node = brick["node"]
+                storage_unit.node_id = brick["node_id"]
+                storage_unit.brick_device_dir = brick["brick_device_dir"]
                 storage_unit.podname = brick["node"].replace(
                     "." + storage.storage_name, "")
                 storage.storage_units.append(storage_unit)

--- a/cli/kubectl_kadalu/utils.py
+++ b/cli/kubectl_kadalu/utils.py
@@ -7,6 +7,7 @@ import sys
 
 KUBECTL_CMD = "kubectl"
 
+# noqa # pylint: disable=too-many-instance-attributes
 # noqa # pylint: disable=useless-object-inheritance
 # noqa # pylint: disable=too-few-public-methods
 # noqa # pylint: disable=bad-option-value

--- a/extras/scripts/cleanup
+++ b/extras/scripts/cleanup
@@ -19,6 +19,7 @@ kubectl get storageclass | grep kadalu | awk '{print $1}' | xargs kubectl delete
 
 # Operator
 kubectl delete -nkadalu CustomResourceDefinition kadalustorages.kadalu-operator.storage
+kubectl delete -nkadalu ClusterRole pod-exec
 kubectl delete -nkadalu ClusterRole kadalu-operator
 kubectl delete -nkadalu ServiceAccount kadalu-operator
 kubectl delete -nkadalu ClusterRoleBinding kadalu-operator

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -10,21 +10,23 @@ RUN python3 -m pip install kubernetes==11.0.0
 
 RUN mkdir -p /kadalu/manifests
 
-COPY templates/services.yaml.j2      /kadalu/templates/services.yaml.j2
-COPY templates/server.yaml.j2        /kadalu/templates/server.yaml.j2
-COPY templates/csi.yaml.j2           /kadalu/templates/csi.yaml.j2
-COPY templates/csi-driver-crd.yaml.j2  /kadalu/templates/csi-driver-crd.yaml.j2
-COPY templates/csi-driver-object.yaml.j2  /kadalu/templates/csi-driver-object.yaml.j2
-COPY templates/configmap.yaml.j2     /kadalu/templates/configmap.yaml.j2
+COPY templates/services.yaml.j2             /kadalu/templates/services.yaml.j2
+COPY templates/server.yaml.j2               /kadalu/templates/server.yaml.j2
+COPY templates/csi.yaml.j2                  /kadalu/templates/csi.yaml.j2
+COPY templates/csi-driver-crd.yaml.j2       /kadalu/templates/csi-driver-crd.yaml.j2
+COPY templates/csi-driver-object.yaml.j2    /kadalu/templates/csi-driver-object.yaml.j2
+COPY templates/configmap.yaml.j2            /kadalu/templates/configmap.yaml.j2
 COPY templates/storageclass-kadalu.yaml.j2  /kadalu/templates/storageclass-kadalu.yaml.j2
 COPY templates/storageclass-kadalu.replica1.yaml.j2  /kadalu/templates/storageclass-kadalu.replica1.yaml.j2
 COPY templates/storageclass-kadalu.replica2.yaml.j2  /kadalu/templates/storageclass-kadalu.replica2.yaml.j2
 COPY templates/storageclass-kadalu.replica3.yaml.j2  /kadalu/templates/storageclass-kadalu.replica3.yaml.j2
 COPY templates/external-storageclass.yaml.j2  /kadalu/templates/external-storageclass.yaml.j2
-COPY lib/kadalulib.py                /kadalu/kadalulib.py
-COPY operator/main.py                /kadalu/
-COPY cli/build/kubectl-kadalu        /usr/bin/kubectl-kadalu
-COPY lib/startup.sh                  /kadalu/startup.sh
+COPY lib/kadalulib.py                    /kadalu/kadalulib.py
+COPY cli/kubectl_kadalu/storage_list.py  /kadalu/storage_list.py
+COPY cli/kubectl_kadalu/utils.py         /kadalu/utils.py
+COPY operator/main.py                    /kadalu/
+COPY cli/build/kubectl-kadalu            /usr/bin/kubectl-kadalu
+COPY lib/startup.sh                      /kadalu/startup.sh
 
 RUN chmod +x /kadalu/startup.sh
 

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -60,7 +60,6 @@ users:
   - system:serviceaccount:{{ namespace }}:kadalu-operator
   - system:serviceaccount:{{ namespace }}:kadalu-csi-provisioner
   - system:serviceaccount:{{ namespace }}:kadalu-csi-nodeplugin
-
 {% endif %}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -77,6 +76,20 @@ spec:
     singular: kadalustorage
   scope: Namespaced
   version: v1alpha1
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: {{ namespace }}
+  name: pod-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -194,6 +207,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kadalu-operator
+    namespace: {{ namespace }}
+  - kind: ServiceAccount
+    name: pod-exec
     namespace: {{ namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
This PR implements deletion of storage volume which will be called
when kubectl delete -f is performed on the storage.yaml file. It checks
if pvs provisioned from that volume is zero or not and then proceeds to
delete the volume.
    
Changes:
- New class variables in storage_list.StorageUnit to make its use when
  obj is deleted.
- Includes storage_list and utils from cli into kadalu image FS.
- New ClusterRole 'pod-exec' to allow kadalu-operator to make exec into pods
  which has been binded into 'kadalu-operator'
- Delete ClusterRole 'pod-exec' in cleanup file.
- Renamed methods 'execute' which is defined in both kadalulib and utils.

Fixes: #326 

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>