### PR TITLE
csi: fix bug/typo in ext_volume index

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -111,7 +111,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
                                 "gvolname": ext_volume['g_volname'],
                                 "gserver": ext_volume['g_host'],
                                 "fstype": "xfs",
-                                "options": ext_volume['options'],
+                                "options": ext_volume['g_options'],
                             }
                         }
                     )


### PR DESCRIPTION
This patch fixed a typo that causes an exception when indexing ext_volume for external gluster volumes