### PR TITLE
manifests: Allow exec permissions for operator into pods

### DIFF
--- a/manifests/kadalu-operator-devel.yaml
+++ b/manifests/kadalu-operator-devel.yaml
@@ -51,6 +51,20 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  namespace: kadalu
+  name: pod-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kadalu-operator
   namespace: kadalu
 rules:
@@ -163,6 +177,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kadalu-operator
+    namespace: kadalu
+  - kind: ServiceAccount
+    name: pod-exec
     namespace: kadalu
 roleRef:
   kind: ClusterRole

--- a/manifests/kadalu-operator-microk8s-devel.yaml
+++ b/manifests/kadalu-operator-microk8s-devel.yaml
@@ -51,6 +51,20 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  namespace: kadalu
+  name: pod-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kadalu-operator
   namespace: kadalu
 rules:
@@ -163,6 +177,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kadalu-operator
+    namespace: kadalu
+  - kind: ServiceAccount
+    name: pod-exec
     namespace: kadalu
 roleRef:
   kind: ClusterRole

--- a/manifests/kadalu-operator-openshift-devel.yaml
+++ b/manifests/kadalu-operator-openshift-devel.yaml
@@ -62,7 +62,6 @@ users:
   - system:serviceaccount:kadalu:kadalu-csi-provisioner
   - system:serviceaccount:kadalu:kadalu-csi-nodeplugin
 
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -78,6 +77,20 @@ spec:
     singular: kadalustorage
   scope: Namespaced
   version: v1alpha1
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  namespace: kadalu
+  name: pod-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -195,6 +208,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kadalu-operator
+    namespace: kadalu
+  - kind: ServiceAccount
+    name: pod-exec
     namespace: kadalu
 roleRef:
   kind: ClusterRole

--- a/manifests/kadalu-operator-rke-devel.yaml
+++ b/manifests/kadalu-operator-rke-devel.yaml
@@ -51,6 +51,20 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  namespace: kadalu
+  name: pod-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: kadalu-operator
   namespace: kadalu
 rules:
@@ -163,6 +177,9 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kadalu-operator
+    namespace: kadalu
+  - kind: ServiceAccount
+    name: pod-exec
     namespace: kadalu
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
This PR allows the operator to make exec into pods to allow get pv_count for storage
which is done through PR #350.

Changes:
- All changes done through 'make gen-manifest' on templates/operator.j2.yaml

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>