### PR TITLE
across: Use 'apply' instead of 'create'

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -252,7 +252,7 @@ def run(args):
         with os.fdopen(config, 'w') as tmp:
             tmp.write(yaml_content)
 
-        cmd = utils.kubectl_cmd(args) + ["create", "-f", tempfile_path]
+        cmd = utils.kubectl_cmd(args) + ["apply", "-f", tempfile_path]
         resp = utils.execute(cmd)
         print("Storage add request sent successfully")
         print(resp.stdout)

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -20,7 +20,7 @@ Traceback (most recent call last):
   File "/kadalu/main.py", line 458, in main
     deploy_csi_pods(core_v1_client)
   File "/kadalu/main.py", line 394, in deploy_csi_pods
-    execute(KUBECTL_CMD, "create", "-f", filename)
+    execute(KUBECTL_CMD, CREATE_CMD, "-f", filename)
   File "/kadalu/kadalulib.py", line 60, in execute
     raise CommandException(proc.returncode, out.strip(), err.strip())
 kadalulib.CommandException: [1] b'' b'Error from server (AlreadyExists): error when creating "/kadalu/templates/csi-driver-object.yaml": csidrivers.storage.k8s.io "kadalu" already exists'


### PR DESCRIPTION
This PR changes 'create' to 'apply' allowing modifications to be done later.
Apply allows to replace[update] and also create a new resource in k8s cluster which is part of _declarative _management__, whereas the former throws an error when object already exists.

Fixes: #303

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>