### PR TITLE
operator: Remove storage_list dependency from kadalu-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ pylint:
 	@cp lib/kadalulib.py server/
 	@cp lib/kadalulib.py operator/
 	@cp cli/kubectl_kadalu/utils.py operator/
-	@cp cli/kubectl_kadalu/storage_list.py operator/
 	@cp server/kadalu_quotad/quotad.py server/kadalu_quotad/glusterutils.py server/
 	@pylint --disable=W0511 -s n lib/kadalulib.py
 	@pylint --disable=W0511 -s n server/glusterfsd.py
@@ -84,7 +83,6 @@ pylint:
 	@rm server/kadalulib.py
 	@rm operator/kadalulib.py
 	@rm operator/utils.py
-	@rm operator/storage_list.py
 	@rm server/quotad.py
 	@rm server/glusterutils.py
 	@cd cli && make gen-version

--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -19,9 +19,6 @@ class StorageUnit(object):
         self.path = None
         self.device = None
         self.pvc = None
-        self.node = None
-        self.node_id = None
-        self.brick_device_dir = None
 
 class Storage(object):
     """Structure for Storage"""
@@ -78,9 +75,6 @@ def list_storages(cmd_out, _args):
                 storage_unit.path = brick["host_brick_path"]
                 storage_unit.device = brick["brick_device"]
                 storage_unit.pvc = brick["pvc_name"]
-                storage_unit.node = brick["node"]
-                storage_unit.node_id = brick["node_id"]
-                storage_unit.brick_device_dir = brick["brick_device_dir"]
                 storage_unit.podname = brick["node"].replace(
                     "." + storage.storage_name, "")
                 storage.storage_units.append(storage_unit)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -20,13 +20,12 @@ COPY templates/storageclass-kadalu.yaml.j2  /kadalu/templates/storageclass-kadal
 COPY templates/storageclass-kadalu.replica1.yaml.j2  /kadalu/templates/storageclass-kadalu.replica1.yaml.j2
 COPY templates/storageclass-kadalu.replica2.yaml.j2  /kadalu/templates/storageclass-kadalu.replica2.yaml.j2
 COPY templates/storageclass-kadalu.replica3.yaml.j2  /kadalu/templates/storageclass-kadalu.replica3.yaml.j2
-COPY templates/external-storageclass.yaml.j2  /kadalu/templates/external-storageclass.yaml.j2
-COPY lib/kadalulib.py                    /kadalu/kadalulib.py
-COPY cli/kubectl_kadalu/storage_list.py  /kadalu/storage_list.py
-COPY cli/kubectl_kadalu/utils.py         /kadalu/utils.py
-COPY operator/main.py                    /kadalu/
-COPY cli/build/kubectl-kadalu            /usr/bin/kubectl-kadalu
-COPY lib/startup.sh                      /kadalu/startup.sh
+COPY templates/external-storageclass.yaml.j2         /kadalu/templates/external-storageclass.yaml.j2
+COPY lib/kadalulib.py                       /kadalu/kadalulib.py
+COPY cli/kubectl_kadalu/utils.py            /kadalu/utils.py
+COPY operator/main.py                       /kadalu/
+COPY cli/build/kubectl-kadalu               /usr/bin/kubectl-kadalu
+COPY lib/startup.sh                         /kadalu/startup.sh
 
 RUN chmod +x /kadalu/startup.sh
 


### PR DESCRIPTION
This PR removes storage_list dependency from the kadalu-operator.

Allowing to avoid Storage and StorageUnit intialization.

Gets the storage to be deleted from 'obj' and rest of the related information
directly from kadalu configmap. Reducing the current traversal time on Storage and StrorageUnit.

Fixes: #366 

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>