### PR TITLE
cli: New subcommand 'storage-remove'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ pylint:
 	@rm server/quotad.py
 	@rm server/glusterutils.py
 	@cd cli && make gen-version
-	@cd cli/kubectl_kadalu && pylint --disable W0511 *.py
+	@cd cli/kubectl_kadalu && pylint --disable W0511,R0801 *.py
 
 ifeq ($(KADALU_VERSION), latest)
 prepare-release-manifests:

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -14,7 +14,7 @@ pytest:
 	${PYTHON} -m pytest kubectl_kadalu
 
 pylint:
-	cd kubectl_kadalu && ${PYTHON} -m pylint --disable W0511 *.py
+	cd kubectl_kadalu && ${PYTHON} -m pylint --disable W0511,R0801 *.py
 
 mypy:
 	cd kubectl_kadalu && ${PYTHON} -m mypy *.py

--- a/cli/kubectl_kadalu/__main__.py
+++ b/cli/kubectl_kadalu/__main__.py
@@ -6,9 +6,11 @@ from __future__ import print_function
 
 from argparse import ArgumentParser
 
-import storage_add
 import install
+import storage_add
 import storage_list
+import storage_remove
+
 from version import VERSION
 
 
@@ -20,6 +22,7 @@ def get_args():
     install.set_args("install", subparsers)
     storage_add.set_args("storage-add", subparsers)
     storage_list.set_args("storage-list", subparsers)
+    storage_remove.set_args("storage-remove", subparsers)
     version_set_args("version", subparsers)
 
     return parser.parse_args()
@@ -48,6 +51,9 @@ def main():
         elif args.mode == "storage-list":
             storage_list.validate(args)
             storage_list.run(args)
+        elif args.mode == 'storage-remove':
+            storage_remove.validate(args)
+            storage_remove.run(args)
         elif args.mode == "version":
             show_version()
     except KeyboardInterrupt:

--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -2,6 +2,9 @@
 'storage-add ' sub command
 """
 
+# noqa # pylint: disable=duplicate-code
+# noqa # pylint: disable=too-many-branches
+
 #To prevent Py2 to interpreting print(val) as a tuple.
 from __future__ import print_function
 
@@ -14,7 +17,6 @@ import utils
 from storage_yaml import to_storage_yaml
 
 
-# noqa # pylint: disable=too-many-branches
 def set_args(name, subparsers):
     """ add arguments, and their options """
     parser = subparsers.add_parser(name)

--- a/cli/kubectl_kadalu/storage_remove.py
+++ b/cli/kubectl_kadalu/storage_remove.py
@@ -1,0 +1,138 @@
+"""
+'storage-remove' sub command
+"""
+
+# noqa # pylint: disable=duplicate-code
+# noqa # pylint: disable=too-many-branches
+
+#To prevent Py2 to interpreting print(val) as a tuple.
+from __future__ import print_function
+from string import Template
+
+import os
+import tempfile
+import sys
+import json
+
+import utils
+
+YAML_TEMPLATE = """apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "${name}"
+"""
+
+
+def set_args(name, subparsers):
+    """ add arguments, and their options """
+
+    parser = subparsers.add_parser(name)
+    arg = parser.add_argument
+
+    arg(
+        "name",
+        help="Storage Name"
+    )
+    utils.add_global_flags(parser)
+
+
+def validate(args):
+    """
+    Validate the storage requested to be deleted
+    is present in kadalu configmap or not.
+    Exit if not present.
+    """
+
+    storage_info_data = get_configmap_data(args)
+
+    if storage_info_data is None:
+        print("Aborting.....")
+        print("Invalid name. No such storage '%s' in Kadalu configmap." % args.name)
+        sys.exit(1)
+
+
+def get_configmap_data(args):
+    """
+    Get storage info data from kadalu configmap
+    """
+
+    cmd = utils.kubectl_cmd(args) + ["get", "configmap", "kadalu-info", "-nkadalu", "-ojson"]
+
+    try:
+        resp = utils.execute(cmd)
+        config_data = json.loads(resp.stdout)
+
+        volname = args.name
+        data = config_data['data']
+        storage_name = "%s.info" % volname
+        storage_info_data = data[storage_name]
+
+        # Return data in 'dict' format
+        return json.loads(storage_info_data)
+
+    except utils.CommandError as err:
+        utils.command_error(cmd, err.stderr)
+
+    except KeyError:
+        # Validate method expects None when 'storage' not found.
+        return None
+
+
+def storage_add_data(args):
+    """ Build the config file """
+
+    content = {
+        "apiVersion": "kadalu-operator.storage/v1alpha1",
+        "kind": "KadaluStorage",
+        "metadata": {
+            "name": args.name
+        }
+    }
+
+    return content
+
+
+def run(args):
+    """ Adds the subcommand arguments back to main CLI tool """
+
+    yaml_content = Template(YAML_TEMPLATE).substitute(name=args.name)
+
+    print("Storage Yaml file for your reference:\n")
+    print(yaml_content)
+
+    if args.dry_run:
+        return
+
+    if not args.script_mode:
+        answer = ""
+        valid_answers = ["yes", "no", "n", "y"]
+
+        while answer not in valid_answers:
+            answer = input("Is this correct?(Yes/No): ")
+            answer = answer.strip().lower()
+
+        if answer in ["n", "no"]:
+            return
+
+    config, tempfile_path = tempfile.mkstemp(prefix="kadalu")
+    try:
+        with os.fdopen(config, 'w') as tmp:
+            tmp.write(yaml_content)
+
+        cmd = utils.kubectl_cmd(args) + ["delete", "-f", tempfile_path]
+        resp = utils.execute(cmd)
+        print("Storage delete request sent successfully.\n")
+        print(resp.stdout)
+        print()
+
+    except utils.CommandError as err:
+        os.remove(tempfile_path)
+        utils.command_error(cmd, err.stderr)
+
+    except FileNotFoundError:
+        os.remove(tempfile_path)
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+
+    finally:
+        if os.path.exists(tempfile_path):
+            os.remove(tempfile_path)


### PR DESCRIPTION
This PR introduces a new subcommand to kadalu's cli kubectl-kadalu.

Now enables to pass the storage to be deleted as argument and validates,
deletes it if the number of pv_count is 0.

storage-remove builds a new temporary storage-config file with info from
kadalu-config and calls delete on it.
Later gets handled by handle_deleted() through crd_watch().

Fixes: #159

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>