### PR TITLE
helm chart support

### DIFF
--- a/helm/kadalu/.helmignore
+++ b/helm/kadalu/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/kadalu/Chart.yaml
+++ b/helm/kadalu/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: kadalu
+icon: https://kadalu.io/static/css/logo.png
+description: kadalu.io Storage Operator and CSI for k8s (with glusterfs)
+type: application
+version: 0.1.3
+
+appVersion: 0.7.3

--- a/helm/kadalu/templates/NOTES.txt
+++ b/helm/kadalu/templates/NOTES.txt
@@ -1,0 +1,10 @@
+The Kadalu Operator has been installed. Check its status by running:
+  kubectl --namespace {{ .Release.Namespace }} get pods
+
+Visit https://kadalu.io/docs/k8s-storage/latest for instructions on how to add storage and create PVs out of it.
+
+Important Notes:
+- You can add storage pools with different types using 'KadaluStorage' type.
+- The helm chart includes all the RBAC required to create kadalu.io CRD.
+
+

--- a/helm/kadalu/templates/_helpers.tpl
+++ b/helm/kadalu/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kadalu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kadalu.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kadalu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kadalu.labels" -}}
+helm.sh/chart: {{ include "kadalu.chart" . }}
+{{ include "kadalu.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kadalu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kadalu.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kadalu.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kadalu.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/kadalu/templates/clusterrole.yaml
+++ b/helm/kadalu/templates/clusterrole.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-exec
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kadalu-operator
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - customresourcedefinitions
+      - events
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+      - volumeattachments/status
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - servicemonitors
+    verbs: ["get", "create"]
+  - apiGroups: ["kadalu-operator.storage"]
+    resources:
+      - kadalustorages
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch", "delete", "get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["get", "create", "delete", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["get", "create", "delete", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/helm/kadalu/templates/clusterrolebinding.yaml
+++ b/helm/kadalu/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kadalu-operator
+subjects:
+  - kind: ServiceAccount
+    name: kadalu-operator
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: pod-exec
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: kadalu-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/kadalu/templates/deployment.yaml
+++ b/helm/kadalu/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: kadalu
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: kadalu
+  template:
+    metadata:
+      labels:
+        name: kadalu
+    spec:
+      serviceAccountName: kadalu-operator
+      containers:
+        - name: kadalu-operator
+          securityContext:
+            capabilities: {}
+            privileged: true
+          image: docker.io/kadalu/kadalu-operator:devel
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "kadalu-operator"
+            - name: DOCKER_USER
+              value: "kadalu"
+            - name: KADALU_VERSION
+              value: "devel"
+            - name: KADALU_NAMESPCE
+              value: {{ .Release.Namespace }}
+            - name: KUBELET_DIR
+              value: "/var/lib/kubelet"
+            - name: K8S_DIST
+              value: "kubernetes"

--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kadalustorages.kadalu-operator.storage
+  namespace: {{ .Release.Namespace }}
+spec:
+  group: kadalu-operator.storage
+  names:
+    kind: KadaluStorage
+    listKind: KadaluStorageList
+    plural: kadalustorages
+    singular: kadalustorage
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                caps:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/helm/kadalu/templates/serviceaccount.yaml
+++ b/helm/kadalu/templates/serviceaccount.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kadalu-operator
+  namespace: {{ .Release.Namespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: {{ .Release.Namespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-provisioner
+  namespace: {{ .Release.Namespace }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-server-sa
+  namespace: {{ .Release.Namespace }}

--- a/helm/kadalu/values.yaml
+++ b/helm/kadalu/values.yaml
@@ -1,0 +1,26 @@
+# Default values for kadalu
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: kadalu/kadalu-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: devel
+
+serviceAccount:
+  create: true
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+
+resources: {}
+
+autoscaling:
+  enabled: false
+


### PR DESCRIPTION
* Create a helm chart dir
* Add all things from kadalu-operator.yaml to helm chart

How it can be worked out:

```
cd helm
kubectl create namespace kadalu # <- currently this is required
helm install --namespace kadalu kadalu-chart kadalu/ --values kadalu/values.yaml
```

With this PR, we can keep our helm chart open for further contributions.

Updates: #55
Signed-off-by: Amar Tumballi <amar@kadalu.io>