### PR TITLE
cli: Catch ValueError Execption in storage_list.py

### DIFF
--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -207,10 +207,13 @@ def fetch_status(storages, args):
             # num_pvs|used_size|min_pv_size|avg_pv_size|max_pv_size
             pv_stats_parts = parts[1].strip().split("|")
             storage.pv_count = int(pv_stats_parts[0])
-            storage.used_size_bytes = float(pv_stats_parts[1])
-            storage.min_pv_size = float(pv_stats_parts[2])
-            storage.avg_pv_size = float(pv_stats_parts[3])
-            storage.max_pv_size = float(pv_stats_parts[4])
+
+            if storage.pv_count:
+                storage.used_size_bytes = float(pv_stats_parts[1])
+                storage.min_pv_size = float(pv_stats_parts[2])
+                storage.avg_pv_size = float(pv_stats_parts[3])
+                storage.max_pv_size = float(pv_stats_parts[4])
+
         except utils.CommandError as err:
             print("Failed to get size details of the "
                   "storage \"%s\"" % storage.storage_name,


### PR DESCRIPTION
This PR prints default values when PVC count is 0.
Catches ValueError exception when PVC count is '0' or stuck at 'pending' state.

Fixes: #359 

Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>