### PR TITLE
Use ubuntu focal as base image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -34,7 +34,7 @@ jobs:
       -
         name: Run Buildx
         if: success()
-        time_minutes: 144
+        timeout-minutes: 144
         run: |
           KADALU_VERSION=devel docker buildx build \
             --platform linux/arm64,linux/amd64 \

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -53,7 +53,7 @@ jobs:
       -
         name: Run Buildx
         if: success()
-        time_minutes: 144
+        timeout-minutes: 144
         run: |
           KADALU_VERSION=${{ env.kadalu_version }} docker buildx build \
             --platform linux/arm64,linux/amd64 \

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -20,3 +20,21 @@ jobs:
     - name: Run pylint
       run: make pylint
 
+  run-on-minikube:
+    name: kube 1.20.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Docker Dependencies
+      run: sudo apt-get install -y conntrack
+    - name: Build locally
+      run: make build-containers
+    - name: Generate Manifests
+      run: make gen-manifest
+    - name: Setup Minikube
+      run: tests/setup.sh v1.20.0
+    - name: Run tests
+      run: tests/travis-test.sh v1.20.0
+    - name: Cleanup
+      run: tests/cleanup.sh v1.20.0
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,30 @@
 ---
 # need for docker build
 sudo: true
-dist: xenial
-
-addons:
-  apt:
-    packages:
-      - realpath
+dist: focal
 
 services:
   - docker
-
-language: python
-python:
-  - "3.7"
 
 branches:
   only:
     - devel
 
-go: 1.12.x
-
 env:
   global:
     - KADALU_VERSION=canary
-    - GOLANGCI_VERSION=v1.17.0
     - TEST_COVERAGE=stdout
-    - GO_METALINTER_THREADS=1
-    - GO_COVER_DIR=_output
     - VM_DRIVER=none
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
-
-install:
-  - pip install pylint jinja2
-
-before_script:
-  - pylint --version
 
 jobs:
   include:
     - name: kadalu with kube 1.20.0
       script:
-        - sudo apt install -y conntrack
+        - sudo apt-get install -y containerd.io docker-ce docker-ce-cli
+        - sudo apt-get install -y conntrack
+        - sudo systemctl restart docker
         - make build-containers || travis_terminate 1;
         - make gen-manifest || travis_terminate 1;
         - tests/setup.sh v1.20.0 || travis_terminate 1;

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -1,11 +1,6 @@
-FROM kadalu/kadalu-base
+FROM kadalu/kadalu-base:latest
 
-RUN yum install -y glusterfs-fuse
-
-# need these to get grpcio (on arm64/ppc64le/s390x)
-RUN yum -y install make automake gcc-g++ openssl-devel kernel-headers  python3-distutils-extra
-
-RUN python3 -m pip install --upgrade pip setuptools
+RUN apt-get install -y glusterfs-client
 
 # Suggested in one of the issues to speed up pip install
 ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
@@ -13,6 +8,8 @@ ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
 RUN python3 -m pip install grpcio googleapis-common-protos
 
 RUN mkdir -p /kadalu/volfiles /kadalu/templates
+
+RUN mkdir -p /var/log/glusterfs /var/run/gluster
 
 COPY lib/kadalulib.py          /kadalu/
 COPY csi/controllerserver.py   /kadalu/

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,8 @@
-FROM kadalu/kadalu-base
+FROM kadalu/kadalu-base:latest
 
 # Always have the latest stable kubectl
+
+RUN apt-get install -y curl
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`/kubectl -o /usr/bin/kubectl
 
 RUN chmod +x /usr/bin/kubectl

--- a/operator/Dockerfile.base
+++ b/operator/Dockerfile.base
@@ -1,13 +1,12 @@
-FROM docker.io/fedora:33
+FROM docker.io/ubuntu:20.04
 
-RUN yum update -y
-RUN yum -y install procps-ng xfsprogs net-tools telnet wget e2fsprogs python3-pip sqlite
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --no-install-recommends --yes python3
+RUN apt-get install -y xfsprogs net-tools telnet wget e2fsprogs python3-pip sqlite
+# procps-ng
 
 # need below dependencies to have xxhash
-RUN yum -y install gcc python3-devel
-
-RUN yum clean all -y
-RUN rm -rf /var/cache/yum
+RUN uname -m | grep x86_64 || apt-get install -y gcc python3-dev
 
 # Install Python GRPC library and copy all CSI related files
 RUN python3 -m pip install jinja2 requests datetime xxhash

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
-FROM kadalu/kadalu-base
+FROM kadalu/kadalu-base:latest
 
-RUN yum -y install python3-pyxattr glusterfs-server
-RUN rpm -qa | grep gluster | tee /gluster-rpm-versions.txt
+RUN apt-get install -y python3-pyxattr glusterfs-server
+RUN apt list --installed | grep -v WARNING | grep gluster | tee /gluster-rpm-versions.txt
 
 RUN python3 -m pip install glustercli || true && echo "External storage Quota feature may not work"
 
@@ -16,6 +16,8 @@ COPY lib/startup.sh          /kadalu/startup.sh
 COPY server/stop-server.sh   /kadalu/stop-server.sh
 
 RUN mkdir -p /kadalu/templates /kadalu/volfiles
+
+RUN mkdir -p /var/run/gluster /var/log/glusterfs
 
 # Copy Volfile templates
 COPY templates/Replica1.client.vol.j2 /kadalu/templates/

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -126,10 +126,10 @@ function install_minikube() {
 	version=${version[2]}
 	if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
 	    echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
-	    exit 1
+	    #exit 1
 	fi
 	echo "minikube already installed with ${version}"
-	return
+	return 0
     fi
 
     echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
@@ -142,10 +142,10 @@ function install_kubectl() {
 	version=$(kubectl version --client | grep "${KUBE_VERSION}")
 	if [[ "x${version}" != "x" ]]; then
 	    echo "kubectl already installed with ${KUBE_VERSION}"
-	    return
+	    return 0
 	fi
 	echo "installed kubectl version ${version} is not matching requested version ${KUBE_VERSION}"
-	exit 1
+	#exit 1
     fi
     # Download kubectl, which is a requirement for using minikube.
     echo "Installing kubectl. Version: ${KUBE_VERSION}"
@@ -153,10 +153,10 @@ function install_kubectl() {
 }
 
 # configure minikube
-MINIKUBE_VERSION=${MINIKUBE_VERSION:-"latest"}
-KUBE_VERSION=${KUBE_VERSION:-"v1.16.0"}
+MINIKUBE_VERSION=${MINIKUBE_VERSION:-"v1.15.1"}
+KUBE_VERSION=${KUBE_VERSION:-"v1.20.0"}
 MEMORY=${MEMORY:-"3000"}
-VM_DRIVER=${VM_DRIVER:-"virtualbox"}
+VM_DRIVER=${VM_DRIVER:-"none"}
 #configure image repo
 KADALU_IMAGE_REPO=${KADALU_IMAGE_REPO:-"docker.io/kadalu"}
 K8S_IMAGE_REPO=${K8S_IMAGE_REPO:-"quay.io/k8scsi"}
@@ -172,11 +172,12 @@ fi
 
 case "${1:-}" in
 up)
-    install_minikube
+    echo "here"
+    install_minikube || echo "failure"
     #if driver  is 'none' install kubectl with KUBE_VERSION
     if [[ "${VM_DRIVER}" == "none" ]]; then
 	mkdir -p "$HOME"/.kube "$HOME"/.minikube
-	install_kubectl
+	install_kubectl || echo "failure to install kubectl"
     fi
 
     echo "starting minikube with kubeadm bootstrapper"

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -19,7 +19,7 @@ else
     sudo tests/minikube.sh cli_tests
 fi
 
-sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
+#sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
 # functional tests
 # sample test
 


### PR DESCRIPTION
* travis: change ubuntu version
* Ubuntu(20.04 focal) as base image

With ubuntu 20.04 LTS, we get a longer LTS image as a base.
A good idea to keep it handy if someone wants it.

Signed-off-by: Amar Tumballi <amar@kadalu.io>