### PR TITLE
csi: Implement PV Resize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ pylint:
 	@cp server/kadalu_quotad/quotad.py server/kadalu_quotad/glusterutils.py server/
 	@pylint --disable=W0511 -s n lib/kadalulib.py
 	@pylint --disable=W0511 -s n server/glusterfsd.py
-	@pylint --disable=W0511 -s n server/quotad.py
+	@pylint --disable W0511,W0603 -s n server/quotad.py
 	@pylint --disable=W0511 -s n server/server.py
 	@pylint --disable=W0511 -s n server/shd.py
 	@pylint --disable=W0511 -s n csi/controllerserver.py

--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -279,18 +279,14 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
         # Get existing volume
         existing_volume = search_volume(request.volume_id)
 
-        logging.info(logf(
-            "Expansion requested PV size",
-            size=expansion_requested_pvsize
-        ))
-
         # Volume size before expansion
         existing_pvsize = existing_volume.size
         pvname = existing_volume.volname
 
         logging.info(logf(
-            "Existing PV size",
-            size=existing_pvsize
+            "Existing PV size and Expansion requested PV size",
+            existing_pvsize=existing_pvsize,
+            expansion_requested_pvsize=expansion_requested_pvsize
         ))
 
         pvtype = PV_TYPE_SUBVOL

--- a/csi/identityserver.py
+++ b/csi/identityserver.py
@@ -26,11 +26,20 @@ class IdentityServer(csi_pb2_grpc.IdentityServicer):
         capability_type = getattr(
             csi_pb2.PluginCapability.Service, "Type").Value
 
+        # using getattr to avoid Pylint error
+        volume_expansion_type = getattr(
+            csi_pb2.PluginCapability.VolumeExpansion, "Type").Value
+
         return csi_pb2.GetPluginCapabilitiesResponse(
             capabilities=[
                 {
                     "service": {
                         "type": capability_type("CONTROLLER_SERVICE")
+                    }
+                },
+                {
+                    "volume_expansion": {
+                        "type": volume_expansion_type("ONLINE")
                     }
                 }
             ]

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -107,3 +107,11 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
         return csi_pb2.NodeGetInfoResponse(
             node_id=os.environ["NODE_ID"],
         )
+
+    def NodeExpandVolume(self, request, context):
+
+        logging.warning(logf(
+            "NodeExpandVolume called, which is not implemented."
+        ))
+
+        return csi_pb2.NodeExpandVolumeResponse()

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -414,6 +414,7 @@ def is_hosting_volume_free(hostvol, expansion_requested_pvsize):
 
         return False
 
+
 def update_subdir_volume(hostvol_mnt, volname, expansion_requested_pvsize):
     """Update sub directory Volume"""
 

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -74,6 +74,7 @@ rules:
       - services
       - endpoints
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - customresourcedefinitions
       - events
       - configmaps
@@ -131,10 +132,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -105,6 +105,7 @@ rules:
       - services
       - endpoints
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - customresourcedefinitions
       - events
       - configmaps
@@ -162,10 +163,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -74,6 +74,7 @@ rules:
       - services
       - endpoints
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - customresourcedefinitions
       - events
       - configmaps
@@ -131,10 +132,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -74,6 +74,7 @@ rules:
       - services
       - endpoints
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - customresourcedefinitions
       - events
       - configmaps
@@ -131,10 +132,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]

--- a/server/kadalu_quotad/quotad.py
+++ b/server/kadalu_quotad/quotad.py
@@ -93,9 +93,17 @@ def handle_quota(quota_report, brick_path, volname, pvtype):
         data = {}
         with open(pvinfo_file_path) as pvinfo_file:
             data = json.loads(pvinfo_file.read().strip())
-
+            logging.info(logf(
+                "data from pvinfo_file is",
+                file=pvinfo_file,
+                data=data
+            ))
             try:
                 set_quota(os.path.dirname(brick_path), subdir_path, data["size"])
+                logging.info(logf(
+                    "Quota set for size",
+                    size=data["size"]
+                ))
             except CommandException as err:
                 logging.error(logf("Failed to set Quota",
                                    err=err.err,

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -269,12 +269,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/log"]
-    verbs: ["create", "get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/exec"]
-    verbs: ["create", "get", "list", "watch", "update", "patch"]
 
 ---
 kind: Role
@@ -286,6 +280,12 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["create", "get", "list", "watch", "update", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["create", "get", "list", "watch", "update", "patch"]
 
 ---
 kind: RoleBinding

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -405,7 +405,7 @@ spec:
             - name: varlog
               mountPath: "/var/log/gluster"
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.0.1
+          image: docker.io/raspbernetes/csi-external-resizer:1.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -138,6 +138,38 @@ spec:
 
 ## Deploy CSI Provisioner
 ---
+# External Resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["create", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "patch"]
+
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -146,13 +178,16 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch", "create"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -194,6 +229,20 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: kadalu-csi-provisioner
+    namespace: {{ namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: kadalu-csi-provisioner
   namespace: {{ namespace }}
 subjects:
@@ -204,6 +253,7 @@ roleRef:
   kind: ClusterRole
   name: kadalu-csi-provisioner
   apiGroup: rbac.authorization.k8s.io
+
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -219,6 +269,23 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["create", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "patch"]
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ namespace }}
+  name: external-resizer-cfg
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: RoleBinding
@@ -233,6 +300,21 @@ subjects:
 roleRef:
   kind: Role
   name: kadalu-csi-provisioner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-cfg
+  namespace: {{ namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: kadalu-csi-provisioner
+    namespace: {{ namespace }}
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -328,6 +410,21 @@ spec:
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.0.1
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=3m"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: KADALU_VERSION
+              value: "{{ kadalu_version }}"
+            - name: K8S_DIST
+              value: "{{ k8s_dist }}"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
       volumes:
         - name: socket-dir
           emptyDir:

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -163,10 +163,7 @@ rules:
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "pods/log"]
-    verbs: ["create", "get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/exec"]
+    resources: ["pods"]
     verbs: ["create", "get", "list", "watch", "update", "patch"]
 
 ---
@@ -281,10 +278,7 @@ rules:
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
 - apiGroups: [""]
-  resources: ["pods", "pods/log"]
-  verbs: ["create", "get", "list", "watch", "update", "patch"]
-- apiGroups: [""]
-  resources: ["pods", "pods/exec"]
+  resources: ["pods"]
   verbs: ["create", "get", "list", "watch", "update", "patch"]
 
 ---

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -104,6 +104,7 @@ rules:
       - services
       - endpoints
       - persistentvolumeclaims
+      - persistentvolumeclaims/status
       - customresourcedefinitions
       - events
       - configmaps
@@ -161,10 +162,13 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]

--- a/templates/storageclass-kadalu.replica1.yaml.j2
+++ b/templates/storageclass-kadalu.replica1.yaml.j2
@@ -5,5 +5,6 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.replica1
 provisioner: kadalu
+allowVolumeExpansion: true
 parameters:
   hostvol_type: "Replica1"

--- a/templates/storageclass-kadalu.replica2.yaml.j2
+++ b/templates/storageclass-kadalu.replica2.yaml.j2
@@ -5,5 +5,6 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.replica2
 provisioner: kadalu
+allowVolumeExpansion: true
 parameters:
   hostvol_type: "Replica2"

--- a/templates/storageclass-kadalu.replica3.yaml.j2
+++ b/templates/storageclass-kadalu.replica3.yaml.j2
@@ -5,5 +5,6 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.replica3
 provisioner: kadalu
+allowVolumeExpansion: true
 parameters:
   hostvol_type: "Replica3"

--- a/templates/storageclass-kadalu.yaml.j2
+++ b/templates/storageclass-kadalu.yaml.j2
@@ -5,3 +5,4 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu
 provisioner: kadalu
+allowVolumeExpansion: true


### PR DESCRIPTION
This PR introduces support to expand PV volumes. This support is added through adding a new side-car container 'csi-resizer' within 'kadalu-provisioner' image. Implements controller_expand_volume() as per [CSI-spec](https://github.com/container-storage-interface/spec/blob/master/spec.md). 

To expand volume :

1. Set 'allowVolumeExpansion' to 'true' in storage class.
2. Terminate the pod using the volume. [Only for VM attached or these types of volumes.](https://github.com/kubernetes/kubernetes/issues/68427).
3. Patch the pvc to be expanded to new size
    Example :
   ```kubectl patch pvc <pvc-name> -p '{"spec":{"resources":{"requests":{"storage":"70Gi"}}}}}' ```

Notice that size and quota have been updated through:

```kubectl describe pvc <pvc-name>```
and
```kubectl logs -nkadalu server-*  quotad```

> Note: "*" is the storage-pool of which "pvc-name" is part of and found using "kubectl get pods -nkadalu".
> Shrinking of size is not supported. [Read here.](https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/)

Fixes: #45 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>