### PR TITLE
support adding multiple hosts as option in external storage config

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -173,9 +173,10 @@ def storage_add_data(args):
     # External details are specified, no 'storage' section required
     if args.external:
         node, vol = args.external.split(":")
+        nodes = node.split(',')
         content["spec"]["details"] = {
-                "gluster_host": node,
-                "gluster_volname": vol.strip("/")
+            "gluster_hosts": nodes,
+            "gluster_volname": vol.strip("/")
         }
         return content
 

--- a/cli/kubectl_kadalu/storage_yaml.py
+++ b/cli/kubectl_kadalu/storage_yaml.py
@@ -22,7 +22,7 @@ STORAGE_PATH_TMPL = """    - node: "${node}"
 STORAGE_PVC_TMPL = """    - pvc: "${pvc}"
 """
 
-EXTERNAL_TMPL = """    gluster_host: "${gluster_host}"
+EXTERNAL_TMPL = """    gluster_hosts: "${gluster_hosts}"
     gluster_volname: "${gluster_volname}"
     gluster_options: "${gluster_options}"
 """

--- a/cli/kubectl_kadalu/tests/test_storage_yaml.py
+++ b/cli/kubectl_kadalu/tests/test_storage_yaml.py
@@ -19,7 +19,8 @@ PATH_3 = "/exports/kadalu/storage3"
 PVC_1 = "pvc1"
 PVC_2 = "pvc2"
 PVC_3 = "pvc3"
-EXTERNAL_HOST = "gluster1.kadalu.io"
+EXTERNAL_HOSTS = ["gluster1.kadalu.io" , "test"]
+EXTERNAL_HOST = ["gluster1.kadalu.io"]
 EXTERNAL_VOLNAME = "kadalu"
 EXTERNAL_OPTIONS = "log-level=DEBUG"
 
@@ -343,9 +344,9 @@ spec:
   type: "{EXTERNAL}"
   storage: []
   details:
-    - gluster_host: "{EXTERNAL_HOST}"
-      gluster_volname: "{EXTERNAL_VOLNAME}"
-      gluster_options: "{EXTERNAL_OPTIONS}"
+    gluster_hosts: "{EXTERNAL_HOSTS}"
+    gluster_volname: "{EXTERNAL_VOLNAME}"
+    gluster_options: "{EXTERNAL_OPTIONS}"
 """
 
 def test_external_storage():
@@ -357,7 +358,7 @@ def test_external_storage():
             "type": EXTERNAL,
             "details": [
                 {
-                    "gluster_host": EXTERNAL_HOST,
+                    "gluster_hosts": EXTERNAL_HOSTS,
                     "gluster_volname": EXTERNAL_VOLNAME,
                     "gluster_options": EXTERNAL_OPTIONS
                 }

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yq && \
     glusterfs-client build-essential gcc g++ && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade setuptools && \
-    python3 -m pip install jinja2 requests datetime xxhash \
+    python3 -m pip install jinja2 datetime xxhash \
     grpcio googleapis-common-protos && \
     apt-get autoremove --purge -y gcc g++ build-essential python3-dev python3-pip && \
     apt-get -y clean && \

--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -291,7 +291,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
 
         pvtype = PV_TYPE_SUBVOL
         single_node_writer = getattr(csi_pb2.VolumeCapability.AccessMode,
-                                             "SINGLE_NODE_WRITER")
+                                     "SINGLE_NODE_WRITER")
 
         if request.volume_capability.AccessMode == single_node_writer:
             pvtype = PV_TYPE_VIRTBLOCK

--- a/doc/external-gluster-storage.md
+++ b/doc/external-gluster-storage.md
@@ -27,6 +27,7 @@ metadata:
 spec:
   type: External
   details:
+    # gluster_hosts: [ gluster1.kadalu.io, gluster2.kadalu.io ]
     gluster_host: gluster1.kadalu.io
     gluster_volname: kadalu
     gluster_options: log-level=DEBUG

--- a/examples/sample-external-config.yaml
+++ b/examples/sample-external-config.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   type: External
   details:
-    gluster_host: gluster1.kadalu.io
+    gluster_hosts:
+      - gluster1.kadalu.io
     gluster_volname: kadalu
     gluster_options: log-level=DEBUG

--- a/examples/sample-external-storage.yaml
+++ b/examples/sample-external-storage.yaml
@@ -6,7 +6,8 @@ metadata:
 provisioner: kadalu
 parameters:
   hostvol_type: "External"
-  gluster_host: gluster1.kadalu.io   # Change to your gluster host
+  gluster_hosts:
+    - gluster1.kadalu.io             # Change to your gluster host
   gluster_volname: test              # Change to existing gluster volume
   gluster_options: log-level=DEBUG   # Comma separated options
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3.8 curl xfsprogs net-tools telnet wget e2fsprogs python3-pip sqlite build-essential python3-dev && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade setuptools && \
-    python3 -m pip install kubernetes==11.0.0 jinja2 requests datetime xxhash && \
+    python3 -m pip install kubernetes==11.0.0 jinja2 datetime xxhash && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl && \
     apt-get autoremove --purge -y gcc python3-dev build-essential python3-pip curl && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests
 kubernetes
 jinja2
 setuptools

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yq && \
     build-essential && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade setuptools && \
-    python3 -m pip install jinja2 requests datetime xxhash && \
+    python3 -m pip install jinja2 datetime xxhash && \
     (python3 -m pip install glustercli || true && echo "External storage Quota feature may not work") && \
     apt-get autoremove --purge -y gcc build-essential python3-pip python3-dev libffi-dev libssl-dev build-essential && \
     apt-get -y clean && \

--- a/server/setup.py
+++ b/server/setup.py
@@ -11,7 +11,7 @@ setup(
     version=version(),
     packages=["kadalu_quotad"],
     include_package_data=True,
-    install_requires=["requests", "xxhash"],
+    install_requires=["xxhash"],
     extras_require={
         "gluster": ["glustercli"]
     },

--- a/templates/external-storageclass.yaml.j2
+++ b/templates/external-storageclass.yaml.j2
@@ -6,7 +6,7 @@ metadata:
 provisioner: kadalu
 parameters:
   hostvol_type: "External"
-  gluster_host: {{ gluster_host }}
+  gluster_hosts: {{ gluster_hosts }}
   gluster_volname: {{ gluster_volname }}
 {%- if gluster_volname != "" %}
   gluster_options: {{ gluster_options }}

--- a/tests/storage-add.yaml
+++ b/tests/storage-add.yaml
@@ -57,7 +57,7 @@ metadata:
 spec:
   type: External
   details:
-    gluster_host: gluster1.kadalu.io
+    gluster_hosts:
+      - gluster1.kadalu.io
     gluster_volname: kadalu
     gluster_options: log-level=DEBUG
-


### PR DESCRIPTION
There is a need for option similar to gluster's `backup-volfile-servers` option in kadalu when an external storage is used. It is critical to provide high availability, where admin can peacefully give config once and forget about issues of availability of one of the nodes for mounts to work.