### PR TITLE
cli: Fix parsing the device or path list

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -172,7 +172,7 @@ def storage_add_data(args):
 
     # External details are specified, no 'storage' section required
     if args.external:
-        node, vol = args.external.split(":")
+        node, vol = args.external.split(":", 1)
         nodes = node.split(',')
         content["spec"]["details"] = {
             "gluster_hosts": nodes,
@@ -187,7 +187,7 @@ def storage_add_data(args):
     # Device details are specified
     if args.device:
         for devdata in args.device:
-            node, dev = devdata.split(":")
+            node, dev = devdata.split(":", 1)
             content["spec"]["storage"].append(
                 {
                     "node": node,
@@ -198,7 +198,7 @@ def storage_add_data(args):
     # If Path is specified
     if args.path:
         for pathdata in args.path:
-            node, path = pathdata.split(":")
+            node, path = pathdata.split(":", 1)
             content["spec"]["storage"].append(
                 {
                     "node": node,
@@ -217,7 +217,7 @@ def storage_add_data(args):
 
     # TODO: Support for different port can be added later
     if args.type == "Replica2":
-        node, path = args.tiebreaker.split(":")
+        node, path = args.tiebreaker.split(":", 1)
         content["spec"]["tiebreaker"] = {
             "node": node,
             "path": path,


### PR DESCRIPTION
If device path contains `:` character then parsing was failing.

```
$ kubectl kadalu storage-add storage-pool-1 \
    --device node2:/dev/disk/by-id/usb-SanDisk_Ultra_4C530001061023116262-0:0
```

Error:

```
The following nodes are available:
  node1, node2, node3, node4, node5, node6

Traceback (most recent call last):
  File "/Users/hfi/opt/anaconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/hfi/opt/anaconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/bin/kubectl-kadalu/__main__.py", line 58, in <module>
  File "/usr/local/bin/kubectl-kadalu/__main__.py", line 47, in main
  File "/usr/local/bin/kubectl-kadalu/storage_add.py", line 231, in run
  File "/usr/local/bin/kubectl-kadalu/storage_add.py", line 189, in storage_add_data
ValueError: too many values to unpack (expected 2)
```

Added fix to handle the parsing.

Credits: Hans Fischer (https://github.com/hans-fischer)
Fixes: #427
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>