### PR TITLE
Install latest version of GlusterFS

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -4,6 +4,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
 
 RUN apt-get update -yq && \
+    apt install software-properties-common -y && \
+    apt-add-repository -y ppa:gluster/glusterfs-8 && \
+    apt-get update -yq && \
     apt-get install --no-install-recommends -y python3.8 xfsprogs \
     net-tools telnet wget e2fsprogs python3-pip sqlite python3-dev \
     glusterfs-client build-essential gcc g++ && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
+    apt install software-properties-common -y && \
+    apt-add-repository -y ppa:gluster/glusterfs-8 && \
+    apt-get update -yq && \
     apt-get install --no-install-recommends -y python3.8 xfsprogs \
     net-tools telnet wget e2fsprogs python3-pip sqlite gcc python3-dev \
     python3-pyxattr glusterfs-server libffi-dev libssl-dev \


### PR DESCRIPTION
Go with glusterfs-8 which is supported right now, and in later versions, change it to glusterfs-9.

Signed-off-by: Amar Tumballi <amar@kadalu.io>