### PR TITLE
Operator: add 'persistentvolumes' in ClusterRole

### DIFF
--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -152,6 +152,7 @@ rules:
       - pods
       - services
       - endpoints
+      - persistentvolumes
       - persistentvolumeclaims
       - persistentvolumeclaims/status
       - customresourcedefinitions


### PR DESCRIPTION
Resizer needs the permission for 'persistentvolumes' ClusterRole

Fixes: #441 
Signed-off-by: Amar Tumballi <amar@kadalu.io>