### PR TITLE
Make helm charts part of tests and release

### DIFF
--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -32,6 +32,8 @@ jobs:
   run-on-minikube:
     name: kube 1.20.0
     runs-on: ubuntu-latest
+    env:
+      KUBE_VERSION: v1.20.0
     # Skip based on commit message
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -43,9 +45,21 @@ jobs:
     - name: Generate Manifests
       run: VERBOSE="true" make gen-manifest
     - name: Setup Minikube
-      run: tests/setup.sh v1.20.0
+      run: tests/setup.sh $KUBE_VERSION
     - name: Run tests
-      run: tests/travis-test.sh v1.20.0
+      run: tests/travis-test.sh $KUBE_VERSION
     - name: Cleanup
-      run: tests/cleanup.sh v1.20.0
+      run: tests/cleanup.sh $KUBE_VERSION
 
+      # Deploy KaDalu via Helm and run tests if PR address Helm charts
+    - name: Setup Minikube for Helm Charts
+      if: "contains(github.event.head_commit.message, '[helm]')"
+      run: tests/setup.sh $KUBE_VERSION
+    - name: Run tests
+      if: "contains(github.event.head_commit.message, '[helm]')"
+      run: tests/travis-test.sh $KUBE_VERSION
+      env:
+        INSTALL_TYPE: helm
+    - name: Cleanup
+      if: "contains(github.event.head_commit.message, '[helm]')"
+      run: tests/cleanup.sh $KUBE_VERSION

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -62,6 +62,22 @@ jobs:
         overwrite: true
         file_glob: true
 
+  publish-helm-chart:
+    name: Publish Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate tgz archive of Helm Chart
+        run: |
+          KADALU_VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,') make helm-chart
+      - name: Upload Helm Chart archive to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: helm/kadalu/kadalu-helm-chart.tgz
+          overwrite: true
+          file_glob: true
+
   multi-arch-build-for-release:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "    make release           - Publish the built container images"
 	@echo "    make prepare-release-manifests - Prepare release manifest files"
 	@echo "    make cli-build         - Build CLI binary"
+	@echo "    make helm-chart        - Create a tgz archive of Helm chart"
 
 build-grpc:
 	python3 -m grpc_tools.protoc -I./csi/protos --python_out=csi --grpc_python_out=csi ./csi/protos/csi.proto
@@ -114,6 +115,10 @@ pypi-build:
 	echo ${KADALU_VERSION} > server/VERSION
 	cd server; rm -rf dist; python3 setup.py sdist;
 
+helm-chart:
+	@echo "Creating tgz archive of helm chart(Version: ${KADALU_VERSION}).."
+	cd helm; tar -czf kadalu-helm-chart.tgz kadalu
+
 ifeq ($(TWINE_PASSWORD),)
 pypi-upload: pypi-build
 	cd server; twine upload --username kadalu dist/*
@@ -126,7 +131,7 @@ endif
 ifeq ($(KADALU_VERSION), latest)
 release: prepare-release
 else
-release: prepare-release pypi-upload cli-build
+release: prepare-release pypi-upload cli-build helm-chart
 	docker tag ${DOCKER_USER}/kadalu-operator:${KADALU_VERSION} ${DOCKER_USER}/kadalu-operator:${KADALU_LATEST}
 	docker tag ${DOCKER_USER}/kadalu-csi:${KADALU_VERSION} ${DOCKER_USER}/kadalu-csi:${KADALU_LATEST}
 	docker tag ${DOCKER_USER}/kadalu-server:${KADALU_VERSION} ${DOCKER_USER}/kadalu-server:${KADALU_LATEST}


### PR DESCRIPTION
Scope:
- If a commit message contains `[helm]`, default tests will be run
by resources installed from helm chart rather than from manifests
on PR submission
- Create `tgz` archive of helm chart folder and attach as asset
in conjunction with other files as part of release

Out of Scope (at the moment):
- Include deployment from helm chart as part of Travis CI tests
- Auto generation of helm templates from existing yaml files (good
to have feature to have single source)

Assumptions made:
- Created a new job in pr submit workflow (can use existing job
rather than spinning up new VM if needed)
- Used latest available feature release of Helm to deploy chart

Tests (performed locally):
- Tests: `make helm-chart`
- Dry run of installing generated tgz chart with helm
- Yamllint of edited workflows
- Dry run of github actions using https://github.com/nektos/act

Updates: https://github.com/kadalu/kadalu/issues/447

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>