### PR TITLE
volfile: add 'read-fail-log' option to brick volfile

### DIFF
--- a/templates/Replica2.shd.vol.j2
+++ b/templates/Replica2.shd.vol.j2
@@ -1,5 +1,6 @@
 volume {{ volume_id }}-ta
     type protocol/client
+    option transport.socket.read-fail-log false
     option remote-host {{ tiebreaker["node"] }}
     option remote-port {{ tiebreaker["port"] }}
     option remote-subvolume {{ tiebreaker["path"] }}
@@ -9,6 +10,7 @@ end-volume
 volume {{ volname }}-client-{{ brick["brick_index"] }}
     type protocol/client
     option volfile-key /{{ volname }}
+    option transport.socket.read-fail-log false
     option remote-subvolume {{ brick["brick_path"] }}
     option remote-host {{ brick["node"] }}
 end-volume

--- a/templates/brick.vol.j2
+++ b/templates/brick.vol.j2
@@ -66,6 +66,7 @@ end-volume
 volume {{ volname }}-server
     type protocol/server
     option transport-type tcp
+    option transport.socket.read-fail-log false
     option auth.addr.{{ brick_path }}.allow *
     subvolumes {{ brick_path }}
 end-volume


### PR DESCRIPTION
Even with #449 (commit - 596f372) we saw below logs frequently!

```
[2021-03-05 18:33:50.591487 +0000] W [socket.c:764:__socket_rwv] 0-tcp.storage-1-server: readv on 192.168.61.8:49162 failed (No data available)
```

After debugging a bit, realized, this is required on 'server'
(or brick) part also, and hence added the logs in there.

Updates: #314
Signed-off-by: Amar Tumballi <amar@kadalu.io>