### PR TITLE
Fix container name in `get_num_pvs` method

### DIFF
--- a/operator/main.py
+++ b/operator/main.py
@@ -630,7 +630,7 @@ def get_num_pvs(storage_info_data):
 
     cmd = ["kubectl", "exec", "-i",
            bricks[0]['node'].replace("." + volname, ""),
-           "-c", "glusterfsd", "-nkadalu", "--", "sqlite3",
+           "-c", "server", "-nkadalu", "--", "sqlite3",
            dbpath,
            query]
 


### PR DESCRIPTION
- As part of #432 name of the container in server-replica* pod is changed to `server`, however it's missed in `get_num_pvs` method
- Due to which `pv_count` is always `0` in `handle_delete` method
- Still, need to verify whether above issue is responsible for below error or not
```
[2021-03-09 11:26:17,015] WARNING [main - 562:handle_deleted] - Delete requested         volname=replica3-pool
[2021-03-09 11:26:17,274] ERROR [main - 645:get_num_pvs] - Failed to get size details of the storage "replica3-pool"     error=error 1 Error from server (Forbidden): pods "server-replica3-pool-0-0" is forbidden
: User "system:serviceaccount:kadalu:kadalu-operator" cannot create resource "pods/exec" in API group "" in the namespace "kadalu"
```

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>