### PR TITLE
Multiple fixes (sqlite3 in server, and pods/exec permission

### DIFF
--- a/helm/kadalu/templates/clusterrole.yaml
+++ b/helm/kadalu/templates/clusterrole.yaml
@@ -124,3 +124,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -222,6 +222,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -253,6 +253,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -222,6 +222,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -222,6 +222,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 kind: ClusterRoleBinding

--- a/operator/main.py
+++ b/operator/main.py
@@ -559,16 +559,24 @@ def handle_deleted(core_v1_client, obj):
 
     storage_info_data = get_configmap_data(volname)
 
-    logging.warning(logf(
+    logging.info(logf(
         "Delete requested",
         volname=volname
     ))
 
     pv_count = get_num_pvs(storage_info_data)
 
+    if pv_count == -1:
+        logging.error(logf(
+            "Storage delete failed. Failed to get PV count",
+            number_of_pvs=pv_count,
+            storage=volname
+        ))
+        return
+
     if pv_count != 0:
 
-        logging.error(logf(
+        logging.warning(logf(
             "Storage delete failed. Storage is not empty",
             number_of_pvs=pv_count,
             storage=volname
@@ -587,6 +595,8 @@ def handle_deleted(core_v1_client, obj):
             volname=volname,
             manifest=filename
         ))
+
+    return
 
 
 def get_configmap_data(volname):
@@ -647,8 +657,8 @@ def get_num_pvs(storage_info_data):
             "storage \"%s\"" % volname,
             error=msg
         ))
-        # Set default as 0
-        return 0
+        # Return error as its -1
+        return -1
 
 
 def delete_server_pods(storage_info_data, obj):

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=kadalu/builder:latest /opt /opt
 COPY --from=kadalu/builder:latest /kadalu /kadalu
 
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 && \
+    apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 sqlite3 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -252,6 +252,9 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Resolves below errors:

1. sqlite not found in $PATH

```
# k kadalu storage-list --status
Failed to get size details of the storage "replica3"
error 1 error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "0d1da253fbf6c4132a7b754053767a2ec18193ebdc25040bdfe242e716faffac": OCI runtime exec failed: exec failed: container_linux.go:370: starting container process caused: exec: "sqlite3": executable file not found in $PATH: unknown
```

2. Permission errors while running a kubectl command from server container

```
[2021-03-10 04:27:18,413] ERROR [main - 638:get_num_pvs] - Failed to get size details of the storage "replica3"  error=error 1 Error from server (Forbidden): pods "server-replica3-0-0" is forbidden: User "system:serviceaccount:kadalu:kadalu-operator" cannot create resource "pods/exec" in API group "" in the namespace "kadalu"
```