### PR TITLE
Replica client volfiles: set self-heal options to default

### DIFF
--- a/templates/Replica2.client.vol.j2
+++ b/templates/Replica2.client.vol.j2
@@ -20,13 +20,12 @@ end-volume
 {% for i in range(dht_subvol|length) %}
 volume {{ volname }}-replica-{{ i }}
     type cluster/replicate
-    option data-self-heal off
-    option granular-entry-heal no
+    option data-self-heal on
+    option granular-entry-heal on
     option iam-self-heal-daemon off
-    option metadata-self-heal off
-    option self-heal-daemon off
+    option metadata-self-heal on
+    option entry-self-heal on
     option read-hash-mode 5
-    option entry-self-heal off
     option afr-pending-xattr {{ volname }}-client-{{ i * 2 }},{{ volname }}-client-{{ (i * 2) + 1}},{{ volume_id }}-ta
     option thin-arbiter {{ tiebreaker["node"] }}:{{ tiebreaker["path"] }}
     subvolumes {{ volname }}-client-{{ i * 2 }} {{ volname }}-client-{{ (i * 2) + 1}} {{ volume_id }}-ta

--- a/templates/Replica3.client.vol.j2
+++ b/templates/Replica3.client.vol.j2
@@ -12,12 +12,11 @@ end-volume
 {% for i in range(dht_subvol|length) %}
 volume {{ volname }}-replica-{{ i }}
     type cluster/replicate
-    option data-self-heal off
-    option granular-entry-heal no
+    option data-self-heal on
+    option granular-entry-heal on
     option iam-self-heal-daemon off
-    option metadata-self-heal off
-    option self-heal-daemon off
-    option entry-self-heal off
+    option metadata-self-heal on
+    option entry-self-heal on
     option read-hash-mode 5
     subvolumes {{ volname }}-client-{{ i * 3 }} {{ volname }}-client-{{ (i * 3) + 1}} {{ volname }}-client-{{ (i * 3) + 2}}
 end-volume


### PR DESCRIPTION
By this, even if self-heal daemon doesn't work, the client's access
itself can heal the file, thus providing users with an option to
continue, instead of being clueless what to do next.

Fixes: #477
Signed-off-by: Amar Tumballi <amar@kadalu.io>