### PR TITLE
Add minimal IO tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,31 @@
+# Base Dockerfile in https://github.com/Docker-Hub-frolvlad/docker-alpine-python3
+FROM frolvlad/alpine-python3 AS compile
+RUN apk add --no-cache gcc musl-dev git python3-dev && mkdir /opt/bin
+RUN wget https://raw.githubusercontent.com/avati/arequal/master/arequal-checksum.c
+RUN wget https://raw.githubusercontent.com/avati/arequal/master/arequal-run.sh -P /opt/bin/
+RUN sed -i 's/bash/sh/' /opt/bin/arequal-run.sh
+RUN gcc -o /opt/bin/arequal-checksum arequal-checksum.c && chmod +x /opt/bin/arequal*
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install git+https://github.com/vijaykumar-koppad/Crefi.git@7c17a353d19666f230100e92141b49c29546e870
+
+FROM frolvlad/alpine-python3 AS build
+
+ARG version="(unknown)"
+# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+ARG builddate="(unknown)"
+
+LABEL build-date="${builddate}"
+LABEL io.k8s.description="IO container, runs Crefi and validates IO with arequal"
+LABEL name="kadalu-test-io"
+LABEL Summary="Kadalu IO container for CI"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/kadalu/kadalu"
+LABEL vendor="kadalu"
+LABEL version="${version}"
+
+RUN apk add --no-cache rsync
+COPY --from=compile /opt /opt
+
+ENV PATH="/opt/venv/bin:/opt/bin:$PATH"
+CMD ["sh"]

--- a/tests/io-app.yaml
+++ b/tests/io-app.yaml
@@ -1,0 +1,49 @@
+# -*- mode: yaml -*-
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv-io
+spec:
+  storageClassName: kadalu.replica3
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Mi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: io-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: io-app
+  template:
+    metadata:
+      labels:
+        app: io-app
+    spec:
+      containers:
+      - name: io-pod
+        image: docker.io/leelavg/dark-side:latest
+        imagePullPolicy: IfNotPresent
+        command: ['sh', '-c', 'echo "Ready!" && while true; do sleep 10; done;']
+        volumeMounts:
+        - mountPath: '/mnt/alpha'
+          name: csivol
+        livenessProbe:
+          exec:
+            command:
+              - 'sh'
+              - '-ec'
+              - 'df'
+          initialDelaySeconds: 3
+          periodSeconds: 3
+      volumes:
+      - name: csivol
+        persistentVolumeClaim:
+          claimName: pv-io


### PR DESCRIPTION
- Deploy two IO pods
- Write IO sequentially from each pod
- Verify arequal after IO completion
- Ideally will extend CI run only by 2 minutes at max

Updates: https://github.com/kadalu/kadalu/issues/471

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>