### PR TITLE
build scripts: minor tweaks and enable arm64 and arm/v7

### DIFF
--- a/.github/workflows/on-demand-pypi-source-push.yml
+++ b/.github/workflows/on-demand-pypi-source-push.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  multi-arch-build-for-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Python (for cli-build)
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      -
+        name: Build PyPi Image
+        uses: docker/build-push-action@v2
+        timeout-minutes: 260
+        with:
+          context: .
+          file: extras/Dockerfile.python-packages
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            docker.io/kadalu/pypi_source:latest
+          build-args: |
+            version=latest
+            builddate=`date +%Y-%m-%d-%H:%M`
+          secrets: |
+            KADALU_VERSION=latest

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           context: .
           file: extras/Dockerfile.builder
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             docker.io/kadalu/builder:latest
@@ -130,7 +130,7 @@ jobs:
         with:
           context: .
           file: csi/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
           tags: |
@@ -148,7 +148,7 @@ jobs:
         with:
           context: .
           file: operator/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
           tags: |
@@ -166,7 +166,7 @@ jobs:
         with:
           context: .
           file: server/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
           tags: |

--- a/build.sh
+++ b/build.sh
@@ -60,6 +60,12 @@ if [ "x${KADALU_VERSION}" = "x" ]; then
     KADALU_VERSION=${VERSION}
 fi
 
+echo "Building base builder image - This may take a while"
+
+$RUNTIME_CMD $build \
+	     -t "${DOCKER_USER}/builder:latest" "${build_args[@]}" \
+	     --network host -f extras/Dockerfile.builder .
+
 echo "Building images kadalu-\$service:${VERSION}";
 
 build_container "kadalu-server" "server/Dockerfile" ${KADALU_VERSION}

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -8,7 +8,6 @@ FROM ubuntu:20.04 as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends attr python3 libtirpc3 bash && \
-    apt-get install -y --no-install-recommends python3-grpcio >/dev/null && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -20,6 +19,9 @@ COPY --from=builder /opt /opt
 # actual application to be copied here
 # using already installed packages from builder for faster build time
 COPY --from=builder /kadalu /kadalu
+
+# copy grpcio installed in pypi_source image
+COPY --from=kadalu/pypi_source:latest /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
 
 RUN mkdir -p /kadalu/volfiles /kadalu/templates
 RUN mkdir -p /var/log/glusterfs /var/run/gluster

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -2,12 +2,13 @@ FROM kadalu/builder:latest as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
-RUN python3 -m pip install grpcio googleapis-common-protos >/dev/null
+RUN python3 -m pip install googleapis-common-protos
 
 FROM ubuntu:20.04 as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends attr python3 libtirpc3 bash && \
+    apt-get install -y --no-install-recommends python3-grpcio >/dev/null && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -11,15 +11,15 @@ RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3 curl xfsprogs net-tools telnet wget e2fsprogs \
     python3-pip sqlite build-essential g++ python3-dev flex bison openssl libssl-dev libtirpc-dev liburcu-dev \
     libfuse-dev libuuid1 python3-distutils uuid-dev acl-dev libtool automake autoconf git pkg-config \
-    python3-venv libffi-dev && \
+    python3-venv python3-wheel libffi-dev && \
     git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
-    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install >/dev/null && cd ..) && \
+    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install-strip >/dev/null && cd ..) && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl &&  \
     python3 -m venv $VIRTUAL_ENV && cd /kadalu && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade setuptools && \
-    pip install glustercli prometheus-client jinja2 requests datetime xxhash pyxattr
+    pip install prometheus-client jinja2 requests datetime xxhash
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -21,6 +21,8 @@ RUN apt-get update -yq && \
     python3 -m pip install --upgrade setuptools && \
     pip install prometheus-client jinja2 requests datetime xxhash
 
+RUN sed -i "s/include-system-site-packages = false/include-system-site-packages = true/g" /kadalu/pyvenv.cfg
+
 # Debugging, Comment the above line and
 # uncomment below line
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/extras/Dockerfile.python-packages
+++ b/extras/Dockerfile.python-packages
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends python3 python3-pip build-essential g++ python3-dev \
+    python3-distutils libtool automake autoconf pkg-config \
+    python3-venv python3-wheel libffi-dev && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade setuptools && \
+    pip install pyxattr grpcio 2>/dev/null >/dev/null && \
+    apt-get remove --purge -y build-essential g++ python3-dev libtool automake autoconf pkg-config libffi-dev && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Debugging, Comment the above line and
+# uncomment below line
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,6 @@
 FROM kadalu/builder:latest as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
-RUN python3 -m pip install glustercli
 
 FROM ubuntu:20.04 as prod
 
@@ -15,9 +14,11 @@ COPY --from=builder /kadalu /kadalu
 
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 sqlite3 && \
-    apt-get install -y --no-install-recommends python3-pyxattr && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
+
+# copy pyxattr installed in pypi_source image
+COPY --from=kadalu/pypi_source:latest /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
 
 RUN mkdir -p /kadalu/templates /kadalu/volfiles
 RUN mkdir -p /var/run/gluster /var/log/glusterfs
@@ -25,8 +26,6 @@ RUN mkdir -p /var/run/gluster /var/log/glusterfs
 COPY lib/kadalulib.py        /kadalu/kadalulib.py
 COPY server/server.py        /kadalu/server.py
 COPY server/glusterfsd.py    /kadalu/glusterfsd.py
-#COPY server/kadalu_quotad/quotad.py       /kadalu/quotad.py
-#COPY server/kadalu_quotad/glusterutils.py /kadalu/glusterutils.py
 COPY server/shd.py           /kadalu/shd.py
 COPY server/mount-glustervol /usr/bin/mount-glustervol
 COPY lib/startup.sh          /kadalu/startup.sh

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,15 +1,21 @@
+FROM kadalu/builder:latest as builder
+
+ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
+RUN python3 -m pip install glustercli
+
 FROM ubuntu:20.04 as prod
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
-COPY --from=kadalu/builder:latest /opt /opt
+COPY --from=builder /opt /opt
 
 # actual application to be copied here
 # using already installed packages from builder for faster build time
-COPY --from=kadalu/builder:latest /kadalu /kadalu
+COPY --from=builder /kadalu /kadalu
 
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 sqlite3 && \
+    apt-get install -y --no-install-recommends python3-pyxattr && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
* Install grpcio through `apt-get install python3-grpcio` (saves 20-30mins on arm builds)
* Install pyxattr through `apt-get install python3-pyxattr` (saves 20-30mins on arm builds)
  - previously `pynacl` (a dependency) used to take a lot of time with pip install.
* Install glustercli only in server builds.
* Install glusterfs with `make install-strip` to reduce the binary size of glusterfs

Tested on `arm` branch for release, so both `arm64` and `arm/v7` tag works

Fixes: #486 
Updates: #474 

Signed-off-by: Amar Tumballi <amar@kadalu.io>