### PR TITLE
Fix merge workflow

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -114,23 +114,21 @@ jobs:
           secrets: |
             KADALU_VERSION=${{ github.sha }}
 
-      # Until we find a way to get files part of Push event unconditionally build and push test images as well
-      # # What follows are basically building and pushing of tests images conditionally
-      # -
-      #   name: Check for Dockerfile changes in tests folder
-      #   id: build_test
-      #   run: |
-      #     build_test='no'
-      #     URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-      #     FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
-
-      #     if grep -e '^tests.*Dockerfile$' <<< "$FILES"; then
-      #       build_test='yes'
-      #     fi
-      #     echo ::set-output name=build_test::$build_test
+      # What follows are basically building and pushing of tests images conditionally
+      -
+        name: Check for Dockerfile changes in tests folder
+        id: build_test
+        run: |
+          build_test='no'
+          # Get files part of the merge
+          FILES=$(git show --pretty="" --name-only)
+          if grep -e '^tests.*Dockerfile$' <<< "$FILES"; then
+            build_test='yes'
+          fi
+          echo ::set-output name=build_test::$build_test
       -
         name: Build test images used in CI
-        # if: "contains(steps.build_test.outputs.build_test, 'yes')"
+        if: "contains(steps.build_test.outputs.build_test, 'yes')"
         uses: docker/build-push-action@v2
         timeout-minutes: 10
         with:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -114,23 +114,23 @@ jobs:
           secrets: |
             KADALU_VERSION=${{ github.sha }}
 
-      # What follows are basically building and pushing of tests images conditionally
-      -
-        name: Check for Dockerfile changes in tests folder
-        id: build_test
-        run: |
-          echo GITHUB_CONTEXT: "$GITHUB_CONTEXT"
-          build_test='no'
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
+      # Until we find a way to get files part of Push event unconditionally build and push test images as well
+      # # What follows are basically building and pushing of tests images conditionally
+      # -
+      #   name: Check for Dockerfile changes in tests folder
+      #   id: build_test
+      #   run: |
+      #     build_test='no'
+      #     URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+      #     FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
 
-          if grep -e '^tests.*Dockerfile$' <<< "$FILES"; then
-            build_test='yes'
-          fi
-          echo ::set-output name=build_test::$build_test
+      #     if grep -e '^tests.*Dockerfile$' <<< "$FILES"; then
+      #       build_test='yes'
+      #     fi
+      #     echo ::set-output name=build_test::$build_test
       -
         name: Build test images used in CI
-        if: "contains(steps.build_test.outputs.build_test, 'yes')"
+        # if: "contains(steps.build_test.outputs.build_test, 'yes')"
         uses: docker/build-push-action@v2
         timeout-minutes: 10
         with:

--- a/tests/test-io/Dockerfile
+++ b/tests/test-io/Dockerfile
@@ -11,6 +11,7 @@ RUN pip install git+https://github.com/vijaykumar-koppad/Crefi.git@7c17a353d1966
 
 FROM frolvlad/alpine-python3 AS prod
 
+# Version supplied at build time
 ARG version="(unknown)"
 # Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 ARG builddate="(unknown)"


### PR DESCRIPTION
- On PR submit build test containers conditionally
- Until we find a way to get changed files as part of Push
event, unconditionally build and push test images as well

Fixes: https://github.com/kadalu/kadalu/commit/3b12503880726991d57016bb338a0a05b91964f6

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>