### PR TITLE
Use bash 'test' command inside a conditional in CI step

### DIFF
--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -53,7 +53,10 @@ jobs:
           CONTAINERS_FOR=TESTING
         fi
         # In build script, only test containers will be built if this variable is set
-        [[ "$CONTAINERS_FOR" == "TESTING" ]] && CONTAINERS_FOR=TESTING make test-containers
+        if [[ "$CONTAINERS_FOR" == "TESTING" ]]; then
+          CONTAINERS_FOR=TESTING make test-containers
+        fi
+        echo Completed building containers
     - name: Generate Manifests
       run: VERBOSE="yes" make gen-manifest
     - name: Setup Minikube


### PR DESCRIPTION
- If bash 'test' ([]) command used outside of conditional
return code is set '1' on failure at the end
- Change to using 'test' inside a conditional statement

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>