### PR TITLE
[CI] Increase checkout fetch-depth to 2

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -22,6 +22,8 @@ jobs:
       -
         name: Check out Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
- With default(1) fetch-depth all files are being counted as part of single commit
- Due to this Test CI images are being built and pushed on every merge
- Change tested locally

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>