### PR TITLE
Preparation for krew release

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -57,7 +57,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: cli/build/kubectl-kadalu
+        file: cli/build/kubectl-kadalu*
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -26,6 +26,7 @@ release: gen-version
 	@cd build/src && zip -r ../${PROGNAME}.zip *
 	@echo '#!/usr/bin/env ${PYTHON}' | cat - build/${PROGNAME}.zip > build/${PROGNAME}
 	@chmod +x build/${PROGNAME}
+	@cd build && tar -czvf ${PROGNAME}.tar.gz ${PROGNAME}
 	@rm -rf build/src
 	@rm -f build/${PROGNAME}.zip
 	@echo "Single deployment file is ready: build/${PROGNAME}"

--- a/extras/krew.yaml
+++ b/extras/krew.yaml
@@ -1,0 +1,26 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kadalu
+spec:
+  version: "0.8.2"
+  homepage: https://github.com/kadalu/kadalu
+  shortDescription: "Deploy and manage Kadalu Operator, CSI and Storage pods"
+  description: |
+    Kadalu project offers a lightweight Persistent storage solution
+    for applications running in Kubernetes.
+
+    kubectl-kadalu helps to install Kadalu Operator and provides
+    sub-commands to manage/monitor Kadalu Storage pods.
+
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/kadalu/kadalu/releases/download/0.8.2/kubectl-kadalu.tar.gz
+    sha256: ""
+    bin: kubectl-kadalu


### PR DESCRIPTION
Krew(https://krew.sigs.k8s.io) is a package manager for Kubectl Plugins.
Once the Kadalu manifest file is submitted to the krew_index repo,
users can install Kadalu as `kubectl krew install kadalu`.

It expects `zip` or `tar.gz` file available for download while
installing the plugin. With this PR, `tar.gz` file added to the
release and the krew manifest file is added to `extras/krew.yaml`

Following changes are required after each release to submit the
Kadalu manifest file to krew index.

* Update Version and download URL.
* Update sha256 of `kubectl-kadalu.tar.gz` file.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>