### PR TITLE
builder: use 'make install' instead of 'install-strip' for glusterfs

### DIFF
--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -13,7 +13,7 @@ RUN apt-get update -yq && \
     libfuse-dev libuuid1 python3-distutils uuid-dev acl-dev libtool automake autoconf git pkg-config \
     python3-venv python3-wheel libffi-dev && \
     git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
-    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install-strip >/dev/null && cd ..) && \
+    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install >/dev/null && cd ..) && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl &&  \
     python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && \


### PR DESCRIPTION

Heard of some issues in arm64 build with install-stirp decision. Considering
we don't do 'install-strip' anywhere in glusterfs installations right now,
its better to stick with well tested setups.

We can enable it back once all other things are stable! (post v1.0.0)

Signed-off-by: Amar Tumballi <amar@kadalu.io>