### PR TITLE
Disperse Storage Support

### DIFF
--- a/cli/kubectl_kadalu/storage_yaml.py
+++ b/cli/kubectl_kadalu/storage_yaml.py
@@ -60,4 +60,9 @@ def to_storage_yaml(data):
     if data["spec"].get("tiebreaker", None) is not None:
         yaml += Template(TIEBREAKER_TMPL).substitute(**data["spec"]["tiebreaker"])
 
+    if data["spec"].get("disperse", None) is not None:
+        yaml += "  disperse:\n"
+        yaml += "    data: %d\n" % data["spec"]["disperse"]["data"]
+        yaml += "    redundancy: %d\n" % data["spec"]["disperse"]["redundancy"]
+
     return yaml

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -43,6 +43,7 @@ COPY csi/heal-info.sh          /kadalu/
 COPY templates/Replica1.client.vol.j2 /kadalu/templates/
 COPY templates/Replica2.client.vol.j2 /kadalu/templates/
 COPY templates/Replica3.client.vol.j2 /kadalu/templates/
+COPY templates/Disperse.client.vol.j2 /kadalu/templates/
 
 RUN chmod +x /kadalu/startup.sh
 RUN chmod +x /kadalu/heal-info.sh

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -780,8 +780,19 @@ def generate_client_volfile(volname):
         count = 3
         if data["type"] == "Replica2":
             count = 2
-        for i in range(0, int(len(data["bricks"]) / count)):
-            data["dht_subvol"].append("%s-replica-%d" % (data["volname"], i))
+
+        data["subvol_bricks_count"] = count
+        if data["type"] == "Disperse":
+            data["subvol_bricks_count"] = data["disperse"]["data"] + \
+              data["disperse"]["redundancy"]
+            data["disperse_redundancy"] = data["disperse"]["redundancy"]
+
+        for i in range(0, int(len(data["bricks"]) / data["subvol_bricks_count"])):
+            data["dht_subvol"].append("%s-%s-%d" % (
+                data["volname"],
+                "disperse" if data["type"] == "Disperse" else "replica",
+                i
+            ))
 
     template_file_path = os.path.join(
         TEMPLATES_DIR,

--- a/examples/sample-test-app4.yaml
+++ b/examples/sample-test-app4.yaml
@@ -1,0 +1,68 @@
+# -*- mode: yaml -*-
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv4-1
+spec:
+  storageClassName: kadalu.disperse
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 600Mi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4-1
+  labels:
+    app: sample-app
+spec:
+  containers:
+  - name: sample-app
+    image: docker.io/kadalu/sample-pv-check-app:latest
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - mountPath: "/mnt/pv"
+      name: csivol
+  volumes:
+  - name: csivol
+    persistentVolumeClaim:
+      claimName: pv4-1
+  restartPolicy: OnFailure
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv4-2
+spec:
+  storageClassName: kadalu.disperse
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 800Mi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod4-2
+  labels:
+    app: sample-app
+spec:
+  containers:
+  - name: sample-app
+    image: docker.io/kadalu/sample-pv-check-app:latest
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - mountPath: "/mnt/pv"
+      name: csivol
+  volumes:
+  - name: csivol
+    persistentVolumeClaim:
+      claimName: pv4-2
+  restartPolicy: OnFailure

--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -23,6 +23,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -56,6 +56,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -87,6 +87,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -56,6 +56,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -56,6 +56,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -33,6 +33,7 @@ COPY templates/storageclass-kadalu.yaml.j2  /kadalu/templates/storageclass-kadal
 COPY templates/storageclass-kadalu.replica1.yaml.j2  /kadalu/templates/storageclass-kadalu.replica1.yaml.j2
 COPY templates/storageclass-kadalu.replica2.yaml.j2  /kadalu/templates/storageclass-kadalu.replica2.yaml.j2
 COPY templates/storageclass-kadalu.replica3.yaml.j2  /kadalu/templates/storageclass-kadalu.replica3.yaml.j2
+COPY templates/storageclass-kadalu.disperse.yaml.j2  /kadalu/templates/storageclass-kadalu.disperse.yaml.j2
 COPY templates/external-storageclass.yaml.j2         /kadalu/templates/external-storageclass.yaml.j2
 COPY lib/kadalulib.py                       /kadalu/kadalulib.py
 COPY cli/kubectl_kadalu/utils.py            /kadalu/utils.py

--- a/operator/start.py
+++ b/operator/start.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from kadalulib import Monitor, Proc, logging_setup
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,8 +35,10 @@ COPY server/stop-server.sh   /kadalu/stop-server.sh
 COPY templates/Replica1.client.vol.j2 /kadalu/templates/
 COPY templates/Replica2.client.vol.j2 /kadalu/templates/
 COPY templates/Replica3.client.vol.j2 /kadalu/templates/
+COPY templates/Disperse.client.vol.j2 /kadalu/templates/
 COPY templates/Replica2.shd.vol.j2    /kadalu/templates/
 COPY templates/Replica3.shd.vol.j2    /kadalu/templates/
+COPY templates/Disperse.shd.vol.j2    /kadalu/templates/
 COPY templates/brick.vol.j2           /kadalu/templates/
 
 RUN chmod +x /usr/bin/mount-glustervol

--- a/server/shd.py
+++ b/server/shd.py
@@ -30,8 +30,19 @@ def generate_shd_volfile(client_volfile, volname, voltype):
         count = 3
         if data["type"] == "Replica2":
             count = 2
-        for i in range(0, int(len(data["bricks"]) / count)):
-            data["dht_subvol"].append("%s-replica-%d" % (data["volname"], i))
+
+        data["subvol_bricks_count"] = count
+        if data["type"] == "Disperse":
+            data["subvol_bricks_count"] = data["disperse"]["data"] + \
+              data["disperse"]["redundancy"]
+            data["disperse_redundancy"] = data["disperse"]["redundancy"]
+
+        for i in range(0, int(len(data["bricks"]) / data["subvol_bricks_count"])):
+            data["dht_subvol"].append("%s-%s-%d" % (
+                data["volname"],
+                "disperse" if data["type"] == "Disperse" else "replica",
+                i
+            ))
 
     template_file_path = os.path.join(TEMPLATES_DIR,
                                       "%s.shd.vol.j2" % voltype)

--- a/templates/Disperse.client.vol.j2
+++ b/templates/Disperse.client.vol.j2
@@ -1,0 +1,48 @@
+{% for brick in bricks %}
+volume {{ volname }}-client-{{ brick["brick_index"] }}
+    type protocol/client
+    option volfile-key /{{ volname }}
+    option transport.socket.read-fail-log false
+    option remote-subvolume {{ brick["brick_path"] }}
+    option remote-host {{ brick["node"] }}
+end-volume
+
+{% endfor %}
+
+{% for i in range(dht_subvol|length) %}
+volume {{ volname }}-disperse-{{ i }}
+    type cluster/disperse
+    option redundancy {{ disperse_redundancy }}
+    option data-self-heal on
+    option granular-entry-heal on
+    option iam-self-heal-daemon off
+    option metadata-self-heal on
+    option entry-self-heal on
+    option read-hash-mode 5
+    subvolumes {% for b in range(subvol_bricks_count) %} {{ volname }}-client-{{ (i * subvol_bricks_count) + b }}{% endfor %}
+end-volume
+
+{% endfor %}
+
+volume {{ volname }}-dht
+    type cluster/distribute
+    subvolumes {{ dht_subvol|join(' ') }}
+end-volume
+
+volume {{ volname }}-utime
+    type features/utime
+    option noatime on
+    subvolumes {{ volname }}-dht
+end-volume
+
+volume {{ volname }}-write-behind
+    type performance/write-behind
+    option flush-behind on
+    option write-behind on
+    subvolumes {{ volname }}-utime
+end-volume
+
+volume {{ volname }}
+    type debug/io-stats
+    subvolumes {{ volname }}-write-behind
+end-volume

--- a/templates/Disperse.shd.vol.j2
+++ b/templates/Disperse.shd.vol.j2
@@ -1,0 +1,32 @@
+{% for brick in bricks %}
+volume {{ volname }}-client-{{ brick["brick_index"] }}
+    type protocol/client
+    option volfile-key /{{ volname }}
+    option transport.socket.read-fail-log false
+    option remote-subvolume {{ brick["brick_path"] }}
+    option remote-host {{ brick["node"] }}
+end-volume
+
+{% endfor %}
+
+{% for i in range(dht_subvol|length) %}
+volume {{ volname }}-disperse-{{ i }}
+    type cluster/disperse
+    option redundancy {{ disperse_redundancy }}
+    option data-self-heal on
+    option iam-self-heal-daemon true
+    option metadata-self-heal on
+    option self-heal-daemon on
+    option choose-local true
+    option ensure-durability on
+    option data-change-log on
+    option entry-self-heal on
+    subvolumes {% for b in range(subvol_bricks_count) %} {{ volname }}-client-{{ (i * subvol_bricks_count) + b }}{% endfor %}
+end-volume
+
+{% endfor %}
+
+volume {{ volname }}
+    type debug/io-stats
+    subvolumes {{ dht_subvol|join(' ') }}
+end-volume

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -86,6 +86,13 @@ spec:
             spec:
               type: object
               properties:
+                disperse:
+                  type: object
+                  properties:
+                    data:
+                      type: integer
+                    redundancy:
+                      type: integer
                 type:
                   type: string
                 storage:

--- a/templates/storageclass-kadalu.disperse.yaml.j2
+++ b/templates/storageclass-kadalu.disperse.yaml.j2
@@ -1,0 +1,10 @@
+# -*- mode: yaml -*-
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: kadalu.disperse
+provisioner: kadalu
+allowVolumeExpansion: true
+parameters:
+  hostvol_type: "Disperse"

--- a/tests/kubectl_kadalu_tests.sh
+++ b/tests/kubectl_kadalu_tests.sh
@@ -38,6 +38,10 @@ function test_storage_add() {
     # Check if the type default is Replica1
     cli/build/kubectl-kadalu storage-add storage-pool-1 --script-mode --device ${HOSTNAME}:/mnt/${DISK}/file1.1 --device ${HOSTNAME}:/mnt/${DISK}/file1.2 --device ${HOSTNAME}:/mnt/${DISK}/file1.3 || return 1
 
+    # Check for Disperse Volume
+    sleep 1
+    cli/build/kubectl-kadalu storage-add storage-pool-4 --script-mode --type Disperse --data 2 --redundancy 1 --device ${HOSTNAME}:/mnt/${DISK}/file4.1 --device ${HOSTNAME}:/mnt/${DISK}/file4.2 --device ${HOSTNAME}:/mnt/${DISK}/file4.3 || return 1
+
     # Check for external storage
     # TODO: For now, keep the name as 'ext-config' as PVC should use this to send request.
     # TODO: Enable this test after we resume testing external gluster cluster

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -13,7 +13,7 @@ function wait_till_pods_start() {
 	cnt=$((cnt + 1))
 	sleep 2
 	ret=$(kubectl get pods -nkadalu -o wide | grep 'Running' | wc -l)
-	if [[ $ret -ge 9 ]]; then
+	if [[ $ret -ge 12 ]]; then
 	    echo "Successful after $cnt seconds"
 	    break
 	fi
@@ -222,11 +222,11 @@ up)
     if [[ "${VM_DRIVER}" != "none" ]]; then
 	wait_for_ssh
 	# shellcheck disable=SC2086
-	minikube ssh "sudo mkdir -p /mnt/${DISK};sudo rm -rf /mnt/${DISK}/*; sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1}; sudo mkdir -p /mnt/${DISK}/{dir3.2,dir3.2_modified,pvc}"
+	minikube ssh "sudo mkdir -p /mnt/${DISK};sudo rm -rf /mnt/${DISK}/*; sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3}; sudo mkdir -p /mnt/${DISK}/{dir3.2,dir3.2_modified,pvc}"
     else
 	sudo mkdir -p /mnt/${DISK}
   sudo rm -rf /mnt/${DISK}/*
-	sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1}
+	sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3}
 	sudo mkdir -p /mnt/${DISK}/dir3.2
 	sudo mkdir -p /mnt/${DISK}/dir3.2_modified
 	sudo mkdir -p /mnt/${DISK}/pvc
@@ -313,6 +313,8 @@ test_kadalu)
     get_pvc_and_check examples/sample-test-app3.yaml "Replica3" 2 90
 
     get_pvc_and_check examples/sample-test-app1.yaml "Replica1" 2 90
+
+    get_pvc_and_check examples/sample-test-app4.yaml "Disperse" 2 90
 
     #get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 60
 

--- a/tests/storage-add.yaml
+++ b/tests/storage-add.yaml
@@ -64,3 +64,22 @@ spec:
 #       - gluster1.kadalu.io
 #     gluster_volname: kadalu
 #     gluster_options: log-level=DEBUG
+
+# Disperse Volume
+---
+apiVersion: kadalu-operator.storage/v1alpha1
+kind: KadaluStorage
+metadata:
+  name: storage-pool-4
+spec:
+  type: Disperse
+  disperse:
+    data: 2
+    redundancy: 1
+  storage:
+    - node: minikube
+      device: /mnt/DISK/file4.1
+    - node: minikube
+      device: /mnt/DISK/file4.2
+    - node: minikube
+      device: /mnt/DISK/file4.3


### PR DESCRIPTION
Added support for GlusterFS Disperse Volumes. Specify `--type=Disperse`
via CLI or `type: Disperse` in YAML.

New CLI Options:

```
--data NUMBER - Number of Disperse data Storage units
--redundancy NUMBER - Number of Disperse redundancy Storage units
```

YAML options:

```
...
  spec:
    disperse:
      data: 2
      redundancy: 1
...
```

Refer GlusterFS documentation for more details about Disperse Volumes.

https://docs.gluster.org/en/latest/Administrator-Guide/Setting-Up-Volumes/#creating-dispersed-volumes

Fixes: #524
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>