### PR TITLE
Remove namespace from Helm-Included CRD

### DIFF
--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -3,7 +3,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kadalustorages.kadalu-operator.storage
-  namespace: {{ .Release.Namespace }}
 spec:
   group: kadalu-operator.storage
   names:


### PR DESCRIPTION
- There is no such thing as a namespaced CRD
- Helm does this by default already for resources that can be namespaced