### PR TITLE
kadalu-operator image version and KADALU_VERSION, see also #538

### DIFF
--- a/helm/kadalu/templates/deployment.yaml
+++ b/helm/kadalu/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           securityContext:
             capabilities: {}
             privileged: true
-          image: docker.io/kadalu/kadalu-operator:devel
+          image: "docker.io/kadalu/kadalu-operator:{{ .Chart.Version | default "devel" }}"
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -39,7 +39,7 @@ spec:
             - name: DOCKER_USER
               value: "kadalu"
             - name: KADALU_VERSION
-              value: "devel"
+              value: "{{ .Chart.Version | default "devel" }}"
             - name: KADALU_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: KUBELET_DIR


### PR DESCRIPTION
1. lightly change: use the value in .Chart.Version which has already been auto replaced by the build scripts
2. "devel" is reserved as the default
3. i did not found any else bind with "devel" in helm
4. NOTE
    * sorry for not fully tested by scripts in tests/, because i cannot turn minikube up with my local envrionment(apple m1 chip)
    * but i have tested with
        1. ``` export KADALU_VERSION=0.8.2-b && make helm-chart ```
        2. ``` helm install kadalu kadalu-helm-chart.tgz --dry-run ```
        3. and checked the diff with 0.8.2/kadalu-helm-chart.tgz
5. any advice or idea is welcome