### PR TITLE
enable download of armv7 kubectl binary

### DIFF
--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -14,7 +14,7 @@ RUN apt-get update -yq && \
     python3-venv python3-wheel libffi-dev && \
     git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
     (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install >/dev/null && cd ..) && \
-    curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`/kubectl -o /usr/bin/kubectl && \
+    curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|' | sed 's|armv7l|arm|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl &&  \
     python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && \
     python3 -m pip install --upgrade pip && \


### PR DESCRIPTION
Was about to open an issue, but think I figured it out.

> Hi all. Firstly wanted to say this is a great project - I wish I'd found it sooner.
> 
> I am getting kadalu 0.8.2 running with a k3s cluster on armv7 using [these docs](https://kadalu.io/docs/k8s-storage/devel/quick-start-yaml/).
> 
> The expected containers were not starting up, and operator had this error in the logs.
> ```
> [2021-05-23 20:41:56,034] INFO [kadalulib - 369:monitor_proc] - Restarted Process	 name=operator
> Traceback (most recent call last):
>   File "/kadalu/main.py", line 909, in <module>
>     main()
>   File "/kadalu/main.py", line 879, in main
>     uid, upgrade = deploy_config_map(core_v1_client)
>   File "/kadalu/main.py", line 836, in deploy_config_map
>     lib_execute(KUBECTL_CMD, CREATE_CMD, "-f", filename)
>   File "/kadalu/kadalulib.py", line 116, in execute
>     proc = subprocess.Popen(cmd, stderr=subprocess.PIPE,
>   File "/usr/lib/python3.8/subprocess.py", line 854, in __init__
>     self._execute_child(args, executable, preexec_fn, close_fds,
>   File "/usr/lib/python3.8/subprocess.py", line 1702, in _execute_child
>     raise child_exception_type(errno_num, err_msg, err_filename)
> OSError: [Errno 8] Exec format error: '/usr/bin/kubectl'
> ```
> Looking in the container, where `/usr/bin/kubectl` should be sits this:
> ```
> <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.21.0/bin/linux/armv7l/kubectl</Details></Error>
> ```
> That URL doesn't go anywhere.
> 
> I install the latest kubectl in the container through apt and I happily get all the pods I'd expect.
> 
> Point to note: https://dl.k8s.io/release/v1.20.0/bin/linux/arm/kubectl does lead to something, but haven't had time to check that is definitively the arm32 binary - but I imagine it will be.
> 

