### PR TITLE
[no ci] fix actions-gh-pages

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -85,7 +85,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: $HOME/output
+        publish_dir: ./output
 
   multi-arch-build-for-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per [this run](https://github.com/kadalu/kadalu/runs/2681773839?check_suite_focus=true#step:13:15), this action seems to be picking absolute path by default

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>