### PR TITLE
operator: Add volume-id option to storage-config

### DIFF
--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -34,6 +34,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -68,6 +68,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -99,6 +99,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -68,6 +68,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -68,6 +68,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:

--- a/operator/main.py
+++ b/operator/main.py
@@ -524,7 +524,14 @@ def handle_added(core_v1_client, obj):
         return
 
     # Generate new Volume ID
-    obj["spec"]["volume_id"] = str(uuid.uuid1())
+    if obj["spec"].get("volume_id", None) is None:
+        obj["spec"]["volume_id"] = str(uuid.uuid1())
+    # Apply existing Volume ID to recreate storage pool from existing device/path
+    else:
+        logging.info(logf(
+            "Applying existing volume id",
+            volume_id=obj["spec"]["volume_id"]
+        ))
 
     voltype = obj["spec"]["type"]
     if voltype == VOLUME_TYPE_EXTERNAL:

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -98,6 +98,8 @@ spec:
                 pvReclaimPolicy:
                   type: string
                   default: delete
+                volume_id:
+                  type: string
                 storage:
                   type: array
                   items:


### PR DESCRIPTION
This PR enables re-creation of storage-pool by manually entering the volume-id of existing device file or path.
Earlier in case of cleanup of kadalu namespace, pointing to same device/path would throw error.

Fixes: #464
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>