### PR TITLE
CSI/controller: add few validations in ExpandVolume

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -469,6 +469,20 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             return csi_pb2.ControllerExpandVolumeResponse()
 
+        if not request.capacity_range:
+            errmsg = "Capacity Range is empty and must be provided"
+            logging.error(errmsg)
+            context.set_details(errmsg)
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            return csi_pb2.ControllerExpandVolumeResponse()
+
+        if not request.capacity_range.required_bytes:
+            errmsg = "Required Bytes is empty and must be provided"
+            logging.error(errmsg)
+            context.set_details(errmsg)
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            return csi_pb2.ControllerExpandVolumeResponse()
+
         expansion_requested_pvsize = request.capacity_range.required_bytes
 
         # Get existing volume

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -342,7 +342,9 @@ test_kadalu)
     kubectl wait --for=condition=ready pod -l app=sanity-app --timeout=15s
 
     exp_pass=33
-    kubectl exec sanity-app -i -- sh -c 'csi-sanity -ginkgo.v --csi.endpoint $CSI_ENDPOINT -ginkgo.skip pagination' | tee /tmp/sanity-result.txt
+
+    # Set expand vol size to 10MB
+    kubectl exec sanity-app -i -- sh -c 'csi-sanity -ginkgo.v --csi.endpoint $CSI_ENDPOINT -ginkgo.skip pagination -csi.testvolumesize 10485760 -csi.testvolumeexpandsize 10485760' | tee /tmp/sanity-result.txt
 
     # Make sure no more failures than above stats
     act_pass=$(grep -Po '(\d+)(?= Passed)' /tmp/sanity-result.txt 2>/dev/null || echo 0)


### PR DESCRIPTION
* If expected required size is not sent for request,
  the request should error out.
* tests: Reduce the size of ExpandVolume so we won't exceed
  the available size. (Credits @leelavg)

Signed-off-by: Amar Tumballi <amar@kadalu.io>