### PR TITLE
Conditionally deploy socat as part of nodeplugin pod

### DIFF
--- a/extras/scripts/gen_manifest.py
+++ b/extras/scripts/gen_manifest.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
     KADALU_VERSION = os.environ.get("KADALU_VERSION", "latest")
     K8S_DIST = os.environ.get("K8S_DIST", "kubernetes")
     VERBOSE = os.environ.get("VERBOSE", "no")
+    DEPLOY_SOCAT = os.environ.get("DEPLOY_SOCAT", "no")
     KUBELET_DIR = "/var/lib/kubelet"
     if K8S_DIST == "microk8s":
         KUBELET_DIR = "/var/snap/microk8s/common/var/lib/kubelet"
@@ -43,7 +44,8 @@ if __name__ == "__main__":
         "docker_user": DOCKER_USER,
         "k8s_dist": K8S_DIST,
         "kubelet_dir": KUBELET_DIR,
-        "verbose": VERBOSE
+        "verbose": VERBOSE,
+        "deploy_socat": DEPLOY_SOCAT,
     }
 
     template(sys.argv[1], template_file="operator.yaml.j2", template_args=TEMPLATE_ARGS)

--- a/helm/kadalu/templates/deployment.yaml
+++ b/helm/kadalu/templates/deployment.yaml
@@ -52,3 +52,5 @@ spec:
               value: "{{ .Values.kubernetesDistro }}"
             - name: VERBOSE
               value: "{{ .Values.verbose }}"
+            - name: DEPLOY_SOCAT
+              value: "{{ .Values.deploy_socat }}"

--- a/helm/kadalu/values.yaml
+++ b/helm/kadalu/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 kubernetesDistro: kubernetes
 verbose: 'no'
+deploy_socat: 'no'
 
 image:
   repository: kadalu/kadalu-operator

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -311,3 +311,5 @@ spec:
               value: "microk8s"
             - name: VERBOSE
               value: "no"
+            - name: DEPLOY_SOCAT
+              value: "no"

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -342,3 +342,5 @@ spec:
               value: "openshift"
             - name: VERBOSE
               value: "no"
+            - name: DEPLOY_SOCAT
+              value: "no"

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -311,3 +311,5 @@ spec:
               value: "rke"
             - name: VERBOSE
               value: "no"
+            - name: DEPLOY_SOCAT
+              value: "no"

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -311,3 +311,5 @@ spec:
               value: "kubernetes"
             - name: VERBOSE
               value: "no"
+            - name: DEPLOY_SOCAT
+              value: "no"

--- a/operator/main.py
+++ b/operator/main.py
@@ -23,6 +23,7 @@ VERSION = os.environ.get("KADALU_VERSION", "latest")
 K8S_DIST = os.environ.get("K8S_DIST", "kubernetes")
 KUBELET_DIR = os.environ.get("KUBELET_DIR")
 VERBOSE = os.environ.get("VERBOSE", "no")
+DEPLOY_SOCAT = os.environ.get("DEPLOY_SOCAT", "no")
 MANIFESTS_DIR = "/kadalu/templates"
 KUBECTL_CMD = "/usr/bin/kubectl"
 KADALU_CONFIG_MAP = "kadalu-info"
@@ -888,7 +889,8 @@ def deploy_csi_pods(core_v1_client):
     docker_user = os.environ.get("DOCKER_USER", "kadalu")
     template(filename, namespace=NAMESPACE, kadalu_version=VERSION,
              docker_user=docker_user, k8s_dist=K8S_DIST,
-             kubelet_dir=KUBELET_DIR, verbose=VERBOSE)
+             kubelet_dir=KUBELET_DIR, verbose=VERBOSE,
+             deploy_socat=DEPLOY_SOCAT)
 
     lib_execute(KUBECTL_CMD, APPLY_CMD, "-f", filename)
     logging.info(logf("Deployed CSI Pods", manifest=filename))

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -113,6 +113,18 @@ spec:
               mountPath: "/dev"
             - name: varlog
               mountPath: /var/log/gluster
+{% if deploy_socat == "yes" %}
+        - name: csi-socat
+          image: alpine/socat:1.0.5
+          args:
+            - tcp-listen:10000,fork,reuseaddr
+            - unix-connect:/plugin/csi.sock
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+{% endif %}
         - name: kadalu-logging
           image: busybox
           command: ["/bin/sh"]

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -341,3 +341,5 @@ spec:
               value: "{{ k8s_dist }}"
             - name: VERBOSE
               value: "{{ verbose }}"
+            - name: DEPLOY_SOCAT
+              value: "{{ deploy_socat }}"

--- a/tests/test-csi/sanity-debug.yaml
+++ b/tests/test-csi/sanity-debug.yaml
@@ -1,5 +1,5 @@
-# Currently this pod is neither a part of production deployment nor used in CI.
-# Only used for manually debugging KaDalu CSI Driver
+# A shorter version of this is being deployed when 'deploy_socat' pod is set to 'yes' in operator manifest
+# This manifest is only used for manually debugging KaDalu CSI Driver
 
 # Once this pod is deployed you can run below for communicating with CSI driver
 # In one prompt: `kubectl port-forward pods/sanity-ds :10000`
@@ -34,13 +34,13 @@ spec:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/plugin/csi.sock
           volumeMounts:
-            - name: csi-sock
-              mountPath: /plugin/csi.sock
+            - name: plugin-dir
+              mountPath: /plugin
       volumes:
-        - name: csi-sock
+        - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/kadalu/csi.sock
-            type: Socket
+            path: /var/lib/kubelet/plugins_registry/kadalu
+            type: Directory
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -76,11 +76,11 @@ spec:
             - tcp-listen:10001,fork,reuseaddr
             - unix-connect:/plugin/csi.sock
           volumeMounts:
-            - name: csi-sock
-              mountPath: /plugin/csi.sock
+            - name: plugin-dir
+              mountPath: /plugin
       volumes:
-        - name: csi-sock
+        - name: plugin-dir
           hostPath:
             # UID of the POD should be replaced before deployment
-            path: '/var/lib/kubelet/pods/POD_UID/volumes/kubernetes.io~empty-dir/socket-dir/csi.sock'
-            type: Socket
+            path: '/var/lib/kubelet/pods/POD_UID/volumes/kubernetes.io~empty-dir/socket-dir'
+            type: Directory


### PR DESCRIPTION
- One of the niceties to have rather than manually deploying every-time while debugging CSI
- Intentionally not exposing any services and only deploy socat container upon request

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>