### PR TITLE
remove dependency on pypi docker image

### DIFF
--- a/.github/workflows/on-demand-pypi-source-push.yml
+++ b/.github/workflows/on-demand-pypi-source-push.yml
@@ -1,4 +1,4 @@
-name: Release
+name: PyPi images
 
 on:
   # Allow to run this workflow manually from the Actions tab

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -1,4 +1,4 @@
-name: buildx
+name: "On Merge"
 
 # This gets built when a PR gets merged
 

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -1,4 +1,4 @@
-name: Release
+name: "On Release"
 
 on:
   push:
@@ -112,6 +112,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
+            docker.io/kadalu/builder:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/builder:latest
           build-args: |
             version=${{ steps.vars.outputs.tag }}
@@ -132,6 +133,7 @@ jobs:
             docker.io/kadalu/kadalu-csi:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-csi:latest
           build-args: |
+            builder_version=${{ steps.vars.outputs.tag }}
             version=${{ steps.vars.outputs.tag }}
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
@@ -150,6 +152,7 @@ jobs:
             docker.io/kadalu/kadalu-operator:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-operator:latest
           build-args: |
+            builder_version=${{ steps.vars.outputs.tag }}
             version=${{ steps.vars.outputs.tag }}
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
@@ -168,6 +171,7 @@ jobs:
             docker.io/kadalu/kadalu-server:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-server:latest
           build-args: |
+            builder_version=${{ steps.vars.outputs.tag }}
             version=${{ steps.vars.outputs.tag }}
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -1,8 +1,10 @@
-FROM kadalu/builder:latest as builder
+ARG builder_version="latest"
+
+FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
-RUN python3 -m pip install googleapis-common-protos
+RUN python3 -m pip install googleapis-common-protos pyxattr grpcio
 
 FROM ubuntu:20.04 as prod
 ENV DEBIAN_FRONTEND=noninteractive
@@ -21,7 +23,7 @@ COPY --from=builder /opt /opt
 COPY --from=builder /kadalu /kadalu
 
 # copy grpcio installed in pypi_source image
-COPY --from=kadalu/pypi_source:latest /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
+COPY --from=builder /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
 
 RUN mkdir -p /kadalu/volfiles /kadalu/templates
 RUN mkdir -p /var/log/glusterfs /var/run/gluster

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,4 +1,6 @@
-FROM kadalu/builder:latest as builder
+ARG builder_version="latest"
+
+FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,10 @@
-FROM kadalu/builder:latest as builder
+ARG builder_version="latest"
+
+FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
+
+RUN python3 -m pip install pyxattr
 
 FROM ubuntu:20.04 as prod
 
@@ -18,7 +22,7 @@ RUN apt-get update -yq && \
     rm -rf /var/lib/apt/lists/*
 
 # copy pyxattr installed in pypi_source image
-COPY --from=kadalu/pypi_source:latest /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
+COPY --from=builder /usr/local/lib/python3.8/dist-packages /kadalu/lib/python3.8/site-packages/
 
 RUN mkdir -p /kadalu/templates /kadalu/volfiles
 RUN mkdir -p /var/run/gluster /var/log/glusterfs


### PR DESCRIPTION
* pypi images were added to save time to build on arm platform
  (specially for grpcio package). In latest versions, we see that
  it is taking just 2 mins, instead of 90mins. Hence its good to
  remove the dependency (and keep minimum variables)
* Also add a release tag to builder image, so we can debug it if
  needed.

Signed-off-by: Amar Tumballi <amar@kadalu.io>