### PR TITLE
Handle corner case only when storage is created but no PV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ pylint:
 	@pylint --disable=W0603 -s n server/glusterutils.py
 	@pylint --disable=W0511,R0911,W0603 -s n csi/controllerserver.py
 	@pylint --disable=W0511 -s n csi/identityserver.py
-	@pylint --disable=W0511 -s n csi/main.py
+	@pylint --disable=W0511,R1732 -s n csi/main.py
 	@pylint --disable=W0511 -s n csi/nodeserver.py
 	@pylint --disable=W0511,C0302 -s n csi/volumeutils.py
 	@pylint --disable=W0511,C0302 -s n operator/main.py

--- a/operator/main.py
+++ b/operator/main.py
@@ -745,6 +745,11 @@ def get_num_pvs(storage_info_data):
         return pv_count
 
     except CommandError as msg:
+        # If storage is created but no PV is carved then pv_stats table is not
+        # created in SQLITE3
+        if 'no such table' in msg:
+            # We are good to delete server pods
+            return 0
         logging.error(
             logf("Failed to get size details of the "
                  "storage \"%s\"" % volname,

--- a/operator/main.py
+++ b/operator/main.py
@@ -747,7 +747,7 @@ def get_num_pvs(storage_info_data):
     except CommandError as msg:
         # If storage is created but no PV is carved then pv_stats table is not
         # created in SQLITE3
-        if 'no such table' in msg:
+        if "no such table" in msg:
             # We are good to delete server pods
             return 0
         logging.error(

--- a/operator/main.py
+++ b/operator/main.py
@@ -747,7 +747,7 @@ def get_num_pvs(storage_info_data):
     except CommandError as msg:
         # If storage is created but no PV is carved then pv_stats table is not
         # created in SQLITE3
-        if "no such table" in msg:
+        if msg.stderr.find("no such table") != -1:
             # We are good to delete server pods
             return 0
         logging.error(


### PR DESCRIPTION
- This corner case is inhibiting deletion of server pods when no PV is created
- May not happen unless a user creates a wrong storage pool and tries to delete the pool without creating any PV
- In that scenario `pv_stats` table isn't created and current logic prohibits deletion of server pods

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>