### PR TITLE
[no ci] Copy requirements files before building images in workflows

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           python -m pip install -r requirements/ci_merge-requirements.txt
           KADALU_VERSION=devel make cli-build
+      - name: Copy all requirements files to root of the repo for building images
+        run: |
+          cp -r requirements/* .
       -
         name: Builder Image
         uses: docker/build-push-action@v2

--- a/.github/workflows/on-pr-merge_arm.yml
+++ b/.github/workflows/on-pr-merge_arm.yml
@@ -40,6 +40,9 @@ jobs:
         run: |
           python -m pip install -r requirements/ci_merge-requirements.txt
           KADALU_VERSION=devel make cli-build
+      - name: Copy all requirements files to root of the repo for building images
+        run: |
+          cp -r requirements/* .
       -
         name: Build CSI Image and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -99,6 +99,9 @@ jobs:
         run: |
           python -m pip install -r requirements/ci_merge-requirements.txt
           KADALU_VERSION=${{ env.kadalu_version }} make cli-build
+      - name: Copy all requirements files to root of the repo for building images
+        run: |
+          cp -r requirements/* .
       -
         name: Build Builder Image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
- This is a miss in #592 after moving all files into subdir
- Need to copy requirements file into root of the repo for building docker images

Updates: #592

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>