### PR TITLE
CSI: allow kadalu_format 'native' or 'non-native' in all config

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -118,11 +118,6 @@ def validate(args):
                     file=sys.stderr)
             fail = True
 
-        if args.kadalu_format:
-            print("'--kadalu-format' is used only with '--type External'",
-                    file=sys.stderr)
-            fail = True
-
         if fail:
             sys.exit(1)
 
@@ -259,6 +254,9 @@ def storage_add_data(args):
     if args.volume_id:
         content["spec"]["volume_id"] = args.volume_id
 
+    if args.kadalu_format:
+        content["spec"]["kadalu_format"] = args.kadalu_format
+
     # External details are specified, no 'storage' section required
     if args.external:
         node, vol = args.external.split(":", 1)
@@ -274,8 +272,6 @@ def storage_add_data(args):
             "gluster_volname": vol.strip("/"),
             "gluster_options": g_opts,
         }
-        if args.kadalu_format:
-            content["spec"]["details"]["kadalu_format"] = args.kadalu_format
         return content
 
     # Everything below can be provided for a 'Replica3' setup.

--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -80,12 +80,9 @@ def set_args(name, subparsers):
         default=0)
     # Default for 'kadalu-format' is set in CRD
     arg("--kadalu-format",
-            help=(
-                "Can only be used in conjunction with '--external' argument. "
-                "Specifies whether the external cluster should be provisioned "
-                "in kadalu native (1 PV:1 Subdir) or non-native (1 PV: 1 Volu "
-                "me) format. Default: native"
-                ),
+            help=("Specifies whether the  cluster should be provisioned in "
+                  "kadalu native (1 PV:1 Subdir) or non-native "
+                  "(1 PV: 1 Volume) format. Default: native"),
             choices=["native", "non-native"],
             default=None)
     utils.add_global_flags(parser)

--- a/cli/kubectl_kadalu/storage_yaml.py
+++ b/cli/kubectl_kadalu/storage_yaml.py
@@ -56,14 +56,8 @@ def to_storage_yaml(data):
 
     if data["spec"].get("details", None) is not None:
         yaml += "  details:\n"
-        key = "kadalu_format"
-        value = ""
-        if data["spec"]["details"].get(key):
-            value = data["spec"]["details"].pop(key)
         entry = data["spec"]["details"]
         yaml += Template(EXTERNAL_TMPL).substitute(**entry)
-        if value:
-            yaml += '    kadalu_format: "%s"\n' % value
 
     if data["spec"].get("tiebreaker", None) is not None:
         yaml += Template(TIEBREAKER_TMPL).substitute(
@@ -79,5 +73,8 @@ def to_storage_yaml(data):
 
     if data["spec"].get("volume_id", None) is not None:
         yaml +=  "  volume_id: %s\n" % data["spec"]["volume_id"]
+
+    if data["spec"].get("kadalu_format", None) is not None:
+        yaml +=  "  kadalu_format: %s\n" % data["spec"]["kadalu_format"]
 
     return yaml

--- a/cli/kubectl_kadalu/tests/test_storage_yaml.py
+++ b/cli/kubectl_kadalu/tests/test_storage_yaml.py
@@ -354,11 +354,11 @@ metadata:
 spec:
   type: "{EXTERNAL}"
   storage: []
+  kadalu_format: "{NON_NATIVE}"
   details:
     gluster_hosts: {EXTERNAL_HOSTS}
     gluster_volname: "{EXTERNAL_VOLNAME}"
     gluster_options: "{EXTERNAL_OPTIONS}"
-    kadalu_format: "{NON_NATIVE}"
 """
 
 
@@ -369,11 +369,11 @@ def test_external_storage_non_native():
         },
         "spec": {
             "type": EXTERNAL,
+            "kadalu_format": NON_NATIVE,
             "details": {
                 "gluster_hosts": EXTERNAL_HOSTS,
                 "gluster_volname": EXTERNAL_VOLNAME,
-                "gluster_options": EXTERNAL_OPTIONS,
-                "kadalu_format": NON_NATIVE
+                "gluster_options": EXTERNAL_OPTIONS
             }
         }
     }

--- a/cli/kubectl_kadalu/tests/test_storage_yaml.py
+++ b/cli/kubectl_kadalu/tests/test_storage_yaml.py
@@ -354,11 +354,11 @@ metadata:
 spec:
   type: "{EXTERNAL}"
   storage: []
-  kadalu_format: "{NON_NATIVE}"
   details:
     gluster_hosts: {EXTERNAL_HOSTS}
     gluster_volname: "{EXTERNAL_VOLNAME}"
     gluster_options: "{EXTERNAL_OPTIONS}"
+  kadalu_format: {NON_NATIVE}
 """
 
 
@@ -369,12 +369,12 @@ def test_external_storage_non_native():
         },
         "spec": {
             "type": EXTERNAL,
-            "kadalu_format": NON_NATIVE,
             "details": {
                 "gluster_hosts": EXTERNAL_HOSTS,
                 "gluster_volname": EXTERNAL_VOLNAME,
                 "gluster_options": EXTERNAL_OPTIONS
-            }
+            },
+            "kadalu_format": NON_NATIVE
         }
     }
     assert (to_storage_yaml(content) == EXTERNAL_OUTPUT_NON_NATIVE)

--- a/csi/main.py
+++ b/csi/main.py
@@ -30,7 +30,7 @@ def mount_storage():
 
     host_volumes = get_pv_hosting_volumes({})
     for volume in host_volumes:
-        if volume["type"] == "External" and volume["k_format"] == "non-native":
+        if volume["k_format"] == "non-native":
             # Need to skip mounting external non-native mounts in-order for
             # kadalu-quotad not to set quota xattrs
             continue

--- a/doc/external-gluster-storage.adoc
+++ b/doc/external-gluster-storage.adoc
@@ -7,7 +7,7 @@ server processes are not managed by kadalu operator.
 
 In both the ways please note `metadata.name` (let's say `e-vol`) in
 `kind: KadaluStorage` will create a StorageClass with name
-`kadalu.external.<volname>` (`volname` will be replaces with `e-vol`).
+`kadalu.<volname>` (`volname` will be replaces with `e-vol`).
 
 == Using external gluster in kadalu native way
 
@@ -47,8 +47,8 @@ apiVersion: v1
 metadata:
   name: pv-ext-kadalu
 spec:
-  # Add 'kadalu.external.' to name from KadaluStorage kind
-  storageClassName: kadalu.external.ext-config
+  # Add 'kadalu.' to name from KadaluStorage kind
+  storageClassName: kadalu.ext-config
   accessModes:
     - ReadWriteMany
   resources:
@@ -67,13 +67,13 @@ You can also setup the external storage through our `kubectl kadalu` CLI.
 $ kubectl kadalu storage-add store-name --external gluster.kadalu.io:/kadalu
 ----
 
-After this, just use `kadalu.external.store-name` (note that 'store-name' is
+After this, just use `kadalu.store-name` (note that 'store-name' is
 name used for `storage-add`) in PVC yaml, like below:
 
 ----
 ...
 spec:
-  storageClassName: kadalu.external.store-name
+  storageClassName: kadalu.store-name
   ...
 ----
 
@@ -140,7 +140,7 @@ apiVersion: v1
 metadata:
   name: pv-ext
 spec:
-  storageClassName: kadalu.external.pv-ext
+  storageClassName: kadalu.pv-ext
   accessModes:
     - ReadWriteMany
   resources:

--- a/doc/external-gluster-storage.adoc
+++ b/doc/external-gluster-storage.adoc
@@ -31,14 +31,14 @@ metadata:
   name: ext-config
 spec:
   type: External
+  # Omitting 'kadalu_format' or using 'native' as a value will create
+  # 1 PV : 1 Subdir in external gluster volume
+  kadalu_format: native
   details:
     # gluster_hosts: [ gluster1.kadalu.io, gluster2.kadalu.io ]
     gluster_host: gluster1.kadalu.io
     gluster_volname: kadalu
     gluster_options: log-level=DEBUG
-    # Omitting 'kadalu_format' or using 'native' as a value will create
-    # 1 PV : 1 Subdir in external gluster volume
-    kadalu_format: native
 
 # file: pvc-from-external-gluster.yaml
 ---
@@ -127,12 +127,12 @@ metadata:
   name: pv-ext # Keep changing the name for different volumes
 spec:
   type: External
+  # Setting 'kadalu_format' as 'non-native' is important
+  kadalu_format: non-native          # Will map 1 Gluster Volume : 1 PV
   details:
     gluster_host: gluster1.kadalu.io   # Change to your gluster host
     gluster_volname: test              # Change to existing gluster volume
     gluster_options: log-level=DEBUG   # Comma separated options
-    # Setting 'kadalu_format' as 'non-native' is important
-    kadalu_format: non-native          # Will map 1 Gluster Volume : 1 PV
 
 ---
 kind: PersistentVolumeClaim

--- a/doc/storage-config-options.adoc
+++ b/doc/storage-config-options.adoc
@@ -160,7 +160,7 @@ The external mode can be specified with `type` as `External`. And when the type 
 
 [source,console]
 ----
-$ kubectl kadalu storage-add storage-pool1 \
+$ kubectl kadalu storage-add external-pool \
     --external gluster_host:/gluster_volname
 ----
 
@@ -170,7 +170,7 @@ Above,
 * 'gluster_volname': Gluster volume name to be used as kadalu host storage volume. We prefer it to be a new volume created for kadalu.
 
 
-Notice that to create PVC from External Storage config, you need to provide `storageClassName` option as `kadalu.external.{{ config-name }}`. In above case, it becomes **`kadalu.external.ext-config`**.
+Notice that to create PVC from External Storage config, you need to provide `storageClassName` option as `kadalu.{{ config-name }}`. In above case, it becomes **`kadalu.external-pool`**.
 
 
 === How it works?

--- a/examples/sample-external-kadalu-storage.yaml
+++ b/examples/sample-external-kadalu-storage.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: pv-ext-kadalu
 spec:
-  storageClassName: kadalu.external.ext-config # Add 'kadalu.external.' to name from KadaluStorage kind
+  storageClassName: kadalu.ext-config # Add 'kadalu.' to name from KadaluStorage kind
   accessModes:
     - ReadWriteMany
   resources:
@@ -38,7 +38,7 @@ apiVersion: v1
 metadata:
   name: pv-ext-kadalu-1
 spec:
-  storageClassName: kadalu # Add 'kadalu.external.' to name from KadaluStorage kind
+  storageClassName: kadalu # Add 'kadalu.' to name from KadaluStorage kind
   accessModes:
     - ReadWriteMany
   resources:

--- a/examples/sample-external-storage.yaml
+++ b/examples/sample-external-storage.yaml
@@ -18,7 +18,7 @@ apiVersion: v1
 metadata:
   name: pv-ext
 spec:
-  storageClassName: kadalu.external.pv-ext
+  storageClassName: kadalu.pv-ext
   accessModes:
     - ReadWriteMany
   resources:

--- a/examples/sample-external-storage.yaml
+++ b/examples/sample-external-storage.yaml
@@ -5,12 +5,12 @@ metadata:
   name: pv-ext # Keep changing the name for different volumes
 spec:
   type: External
+  kadalu_format: non-native            # Will map 1 Gluster Volume : 1 PV
   details:
     gluster_hosts:
       - gluster1.kadalu.io             # Change to your gluster host
     gluster_volname: test              # Change to existing gluster volume
     gluster_options: log-level=DEBUG   # Comma separated options
-    kadalu_format: non-native          # Will map 1 Gluster Volume : 1 PV
 
 ---
 kind: PersistentVolumeClaim

--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -36,6 +36,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -78,6 +78,3 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -70,6 +70,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -112,9 +112,6 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -143,9 +143,6 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -101,6 +101,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -70,6 +70,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -112,9 +112,6 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -70,6 +70,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -112,9 +112,6 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operator/main.py
+++ b/operator/main.py
@@ -490,7 +490,7 @@ def handle_external_storage_addition(core_v1_client, obj):
         "type": VOLUME_TYPE_EXTERNAL,
         "pvReclaimPolicy": pv_reclaim_policy,
         # CRD would set 'native' but just being cautious
-        "kadalu_format": details.get("kadalu_format", "native"),
+        "kadalu_format": obj["spec"].get("kadalu_format", "native"),
         "gluster_hosts": ",".join(hosts),
         "gluster_volname": details["gluster_volname"],
         "gluster_options": details.get("gluster_options", ""),

--- a/operator/main.py
+++ b/operator/main.py
@@ -840,7 +840,7 @@ def delete_config_map(core_v1_client, obj):
     ))
 
 
-def delete_storage_class(hostvol_name, hostvol_type):
+def delete_storage_class(hostvol_name, _):
     """
     Deletes deployed External and Custom StorageClass
     """

--- a/templates/external-storageclass.yaml.j2
+++ b/templates/external-storageclass.yaml.j2
@@ -2,7 +2,7 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: kadalu.external.{{ volname }}
+  name: kadalu.{{ volname }}
 provisioner: kadalu
 parameters:
   hostvol_type: "External"

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -142,9 +142,6 @@ spec:
                       type: string
                     gluster_options:
                       type: string
-                    kadalu_format:
-                      type: string
-                      default: native
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -100,6 +100,9 @@ spec:
                   default: delete
                 volume_id:
                   type: string
+                kadalu_format:
+                  type: string
+                  default: native
                 storage:
                   type: array
                   items:

--- a/templates/storageclass-kadalu.custom.yaml.j2
+++ b/templates/storageclass-kadalu.custom.yaml.j2
@@ -8,3 +8,4 @@ provisioner: kadalu
 allowVolumeExpansion: true
 parameters:
   storage_name: {{ hostvol_name }}
+  kadalu_format: {{ kadalu_format }}


### PR DESCRIPTION
* also remove '.external' part from storageclass name for external
  as it doesn't make sense anymore after merging #589

Signed-off-by: Amar Tumballi <amar@kadalu.io>