### PR TITLE
on-release: push operator image as last one

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -139,25 +139,6 @@ jobs:
           secrets: |
             KADALU_VERSION=${{ steps.vars.outputs.tag }}
       -
-        name: Build Operator Image and push
-        uses: docker/build-push-action@v2
-        timeout-minutes: 120
-        with:
-          context: .
-          file: operator/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          target: prod
-          push: true
-          tags: |
-            docker.io/kadalu/kadalu-operator:${{ steps.vars.outputs.tag }}
-            docker.io/kadalu/kadalu-operator:latest
-          build-args: |
-            builder_version=${{ steps.vars.outputs.tag }}
-            version=${{ steps.vars.outputs.tag }}
-            builddate=`date +%Y-%m-%d-%H:%M`
-          secrets: |
-            KADALU_VERSION=${{ steps.vars.outputs.tag }}
-      -
         name: Build Storage Server Image and push
         uses: docker/build-push-action@v2
         timeout-minutes: 120
@@ -170,6 +151,25 @@ jobs:
           tags: |
             docker.io/kadalu/kadalu-server:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-server:latest
+          build-args: |
+            builder_version=${{ steps.vars.outputs.tag }}
+            version=${{ steps.vars.outputs.tag }}
+            builddate=`date +%Y-%m-%d-%H:%M`
+          secrets: |
+            KADALU_VERSION=${{ steps.vars.outputs.tag }}
+      -
+        name: Build Operator Image and push
+        uses: docker/build-push-action@v2
+        timeout-minutes: 120
+        with:
+          context: .
+          file: operator/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          target: prod
+          push: true
+          tags: |
+            docker.io/kadalu/kadalu-operator:${{ steps.vars.outputs.tag }}
+            docker.io/kadalu/kadalu-operator:latest
           build-args: |
             builder_version=${{ steps.vars.outputs.tag }}
             version=${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
Currently the release script is taking ~2hrs to complete, which
means the CLI would be ready to download before the images. As
our upgrade procedure is all about restarting the operator image
with the latest version, the operator image should be the last
one to be pushed to repository, to prevent any attempt of upgrades
within that time. This also prevents any 'data' layer access issues
during upgrade.

Updates: https://github.com/kadalu/kadalu/issues/577#issuecomment-887730673

Signed-off-by: Amar Tumballi <amar@kadalu.io>