### PR TITLE
Enforce expand volume at storageclass level

### DIFF
--- a/helm/kadalu/templates/resources.yaml
+++ b/helm/kadalu/templates/resources.yaml
@@ -10,6 +10,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -44,6 +44,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -75,6 +75,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -44,6 +44,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -44,6 +44,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -33,7 +33,6 @@ COPY templates/csi.yaml.j2                  /kadalu/templates/csi.yaml.j2
 COPY templates/csi-driver-crd.yaml.j2       /kadalu/templates/csi-driver-crd.yaml.j2
 COPY templates/csi-driver-object.yaml.j2    /kadalu/templates/csi-driver-object.yaml.j2
 COPY templates/configmap.yaml.j2            /kadalu/templates/configmap.yaml.j2
-COPY templates/storageclass-kadalu.yaml.j2           /kadalu/templates/storageclass-kadalu.yaml.j2
 COPY templates/storageclass-kadalu.custom.yaml.j2    /kadalu/templates/storageclass-kadalu.custom.yaml.j2
 COPY templates/external-storageclass.yaml.j2         /kadalu/templates/external-storageclass.yaml.j2
 COPY lib/kadalulib.py                       /kadalu/kadalulib.py

--- a/operator/main.py
+++ b/operator/main.py
@@ -746,9 +746,12 @@ def get_num_pvs(storage_info_data):
         return pv_count
 
     except CommandError as msg:
-        # If storage is created but no PV is carved then pv_stats table is not
+        # 1. If storage is created but no PV is carved then pv_stats table is not
         # created in SQLITE3
-        if msg.stderr.find("no such table") != -1:
+        # 2. If we fail to create 'server' pod then there'll be no 'server'
+        # container (this'll be hit if supplied 'storageClass' is invalid)
+        if msg.stderr.find("no such table") != -1 or msg.stderr.find(
+                "container not found") != -1:
             # We are good to delete server pods
             return 0
         logging.error(

--- a/templates/external-storageclass.yaml.j2
+++ b/templates/external-storageclass.yaml.j2
@@ -4,7 +4,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.{{ volname }}
 provisioner: kadalu
-allowVolumeExpansion: true
+allowVolumeExpansion: {%- if kadalu_format == "native" %}true{%- else %}false{%- endif %}
 parameters:
   hostvol_type: "External"
   gluster_hosts: {{ gluster_hosts }}

--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -74,6 +74,9 @@ spec:
     listKind: KadaluStorageList
     plural: kadalustorages
     singular: kadalustorage
+    shortNames:
+      - kadalu
+      - kds
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/templates/storageclass-kadalu.custom.yaml.j2
+++ b/templates/storageclass-kadalu.custom.yaml.j2
@@ -5,7 +5,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.{{ hostvol_name }}
 provisioner: kadalu
-allowVolumeExpansion: true
+allowVolumeExpansion: {%- if kadalu_format == "native" %} true{%- else %} false{%- endif %}
 parameters:
   storage_name: {{ hostvol_name }}
   kadalu_format: {{ kadalu_format }}

--- a/templates/storageclass-kadalu.yaml.j2
+++ b/templates/storageclass-kadalu.yaml.j2
@@ -1,8 +1,0 @@
-# -*- mode: yaml -*-
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: kadalu
-provisioner: kadalu
-allowVolumeExpansion: true


### PR DESCRIPTION
- Dynamically set `allowVolumeExpansion` while creating storageClass
- Remove deploying default `kadalu` storageClass
- Add `shortNames` to Kadalu CRD
- Corner case while deleting custom kadalu storageClass when `server` pod doesn't exist

Ref: #589, #597, #607

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>