### PR TITLE
Added Prometheus metrics to expose the capacities of sub volumes

### DIFF
--- a/csi/exporter.py
+++ b/csi/exporter.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import time
 import logging
 
@@ -6,7 +7,7 @@ from prometheus_client.core import GaugeMetricFamily, \
      CounterMetricFamily, REGISTRY
 from prometheus_client import start_http_server
 
-from volumeutils import HOSTVOL_MOUNTDIR
+from volumeutils import (HOSTVOL_MOUNTDIR, PV_TYPE_SUBVOL)
 from kadalulib import logging_setup, logf
 
 
@@ -44,6 +45,21 @@ class CsiMetricsCollector(object):
             'Kadalu Storage Inodes free Count',
             labels=capacity_labels
         )
+        subvol_capacity_bytes = GaugeMetricFamily(
+            'kadalu_storage_subvol_capacity_bytes',
+            'Kadalu Storage Sub Volume Capacity',
+            labels=capacity_labels+["subvol"]
+        )
+        subvol_capacity_used_bytes = GaugeMetricFamily(
+            'kadalu_storage_subvol_capacity_used_bytes',
+            'Kadalu Storage Sub Volume Used Capacity',
+            labels=capacity_labels+["subvol"]
+        )
+        subvol_capacity_free_bytes = GaugeMetricFamily(
+            'kadalu_storage_subvol_capacity_free_bytes',
+            'Kadalu Storage Sub Volume Free Capacity',
+            labels=capacity_labels+["subvol"]
+        )
 
         for dirname in os.listdir(HOSTVOL_MOUNTDIR):
             labels = [dirname]  # TODO: Add more labels
@@ -67,12 +83,33 @@ class CsiMetricsCollector(object):
                 inodes_free_count.add_metric(labels, free)
                 inodes_used_count.add_metric(labels, used)
 
+                # Gathers capacity metrics for each subvol
+                pvcpath = pathlib.Path(os.path.join(pth, PV_TYPE_SUBVOL)).glob("*/*/*")
+                for subvol in pvcpath:
+                    if pathlib.Path(subvol).is_dir():
+                        pvcname = os.path.basename(subvol)
+                        pvclabels = labels + [pvcname]
+                        try:
+                            # Get extended attributes for pvc
+                            size = os.getxattr(subvol, "trusted.gfs.squota.size")
+                            limit = os.getxattr(subvol, "trusted.gfs.squota.limit")
+                            subvol_capacity_bytes.add_metric(pvclabels, limit)
+                            subvol_capacity_used_bytes.add_metric(pvclabels, size)
+                            # Convert bytes type into int to compute the free capacity of the subvol
+                            free = int(limit.decode("utf-8")) - int(size.decode("utf-8"))
+                            subvol_capacity_free_bytes.add_metric(pvclabels, free)
+                        except Exception:
+                            pass
+
         yield capacity_bytes
         yield capacity_free_bytes
         yield capacity_used_bytes
         yield inodes_count
         yield inodes_free_count
         yield inodes_used_count
+        yield subvol_capacity_bytes
+        yield subvol_capacity_used_bytes
+        yield subvol_capacity_free_bytes
 
 
 REGISTRY.register(CsiMetricsCollector())

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1219,7 +1219,7 @@ def yield_pvc_from_mntdir(mntdir):
                 data = json.loads(handle.read().strip())
             logging.debug(
                 logf("Found a PVC at", path=file_path, size=data.get("size")))
-            yield name[name.find("pvc"):name.find(".json")], data.get("size")
+            yield name[name.find("pvc"):name.find(".json")], data.get("size"), , data.get("path_prefix")
 
 
 def yield_pvc_from_hostvol():

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1219,7 +1219,7 @@ def yield_pvc_from_mntdir(mntdir):
                 data = json.loads(handle.read().strip())
             logging.debug(
                 logf("Found a PVC at", path=file_path, size=data.get("size")))
-            yield name[name.find("pvc"):name.find(".json")], data.get("size"), , data.get("path_prefix")
+            yield name[name.find("pvc"):name.find(".json")], data.get("size"), data.get("path_prefix")
 
 
 def yield_pvc_from_hostvol():

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1219,7 +1219,8 @@ def yield_pvc_from_mntdir(mntdir):
                 data = json.loads(handle.read().strip())
             logging.debug(
                 logf("Found a PVC at", path=file_path, size=data.get("size")))
-            yield name[name.find("pvc"):name.find(".json")], data.get("size"), data.get("path_prefix")
+            yield name[name.find("pvc"):name.find(".json")], data.get("size"), \
+                data.get("path_prefix")
 
 
 def yield_pvc_from_hostvol():


### PR DESCRIPTION
Hi,
I couldn't get the gluster-metrics-exporter app to work in an internal glusterfs context, so I made a small improvement in csi/export.py to expose in Prometheus the disk capacities of sub volumes (free, used, total).