### PR TITLE
Use buildx while building local images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,16 @@
 
 set -e -o pipefail
 
-cp requirements/* .
+cp -f requirements/*-requirements.txt .
 trap "rm -f *-requirements.txt" EXIT
 
 DOCKER_USER="${DOCKER_USER:-kadalu}"
 KADALU_VERSION="${KADALU_VERSION}"
 
 RUNTIME_CMD=${RUNTIME_CMD:-docker}
-build="build"
+# Use buildx for docker to simulate release script in github workflow
+# Requires Docker >=v19.03
+build="buildx build"
 if [[ "${RUNTIME_CMD}" == "buildah" ]]; then
         build="bud"
 fi

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -7,8 +7,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV VIRTUAL_ENV=/kadalu
 ENV PATH="$VIRTUAL_ENV/bin:/opt/sbin:/opt/bin:$PATH"
 
-COPY builder-requirements.txt /tmp/
-
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3 curl xfsprogs net-tools telnet wget e2fsprogs zlib1g-dev liburcu6\
     python3-pip sqlite3 build-essential g++ python3-dev flex bison openssl libssl-dev libtirpc-dev liburcu-dev \
@@ -17,8 +15,10 @@ RUN apt-get update -yq && \
     git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
     (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install >/dev/null && cd ..) && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|' | sed 's|armv7l|arm|'`/kubectl -o /usr/bin/kubectl && \
-    chmod +x /usr/bin/kubectl &&  \
-    python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && \
+    chmod +x /usr/bin/kubectl
+
+COPY builder-requirements.txt /tmp/
+RUN python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && \
     python3 -m pip install -r /tmp/builder-requirements.txt
 
 RUN sed -i "s/include-system-site-packages = false/include-system-site-packages = true/g" /kadalu/pyvenv.cfg


### PR DESCRIPTION
- Use buildx for building local images to simulate release scripts
- Break python instructions onto separate line from builder dockerfile
- Copy only requirements files while building local images

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>