### PR TITLE
Fix all possible docker issues wrt local and CI builds

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -56,6 +56,7 @@ jobs:
           file: extras/Dockerfile.builder
           platforms: linux/amd64
           push: false
+          load: true
           tags: |
             docker.io/kadalu/builder:latest
           build-args: |
@@ -73,6 +74,7 @@ jobs:
           platforms: linux/amd64
           target: prod
           push: true
+          load: true
           tags: |
             docker.io/kadalu/kadalu-csi:${{ github.sha }}
             docker.io/kadalu/kadalu-csi:devel
@@ -91,6 +93,7 @@ jobs:
           platforms: linux/amd64
           target: prod
           push: true
+          load: true
           tags: |
             docker.io/kadalu/kadalu-operator:${{ github.sha }}
             docker.io/kadalu/kadalu-operator:devel
@@ -109,6 +112,7 @@ jobs:
           platforms: linux/amd64
           target: prod
           push: true
+          load: true
           tags: |
             docker.io/kadalu/kadalu-server:${{ github.sha }}
             docker.io/kadalu/kadalu-server:devel
@@ -141,6 +145,7 @@ jobs:
           platforms: linux/amd64
           target: prod
           push: true
+          load: true
           tags: |
             docker.io/kadalu/test-io:${{ github.sha }}
             docker.io/kadalu/test-io:devel
@@ -160,6 +165,7 @@ jobs:
           platforms: linux/amd64
           target: prod
           push: true
+          load: true
           tags: |
             docker.io/kadalu/test-csi:${{ github.sha }}
             docker.io/kadalu/test-csi:devel

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -72,6 +72,8 @@ jobs:
         overwrite: true
         file_glob: true
 
+  # Use no-cache while building images as they may break release and they are built
+  # only during release so the delay/bandwidth worth the time
   multi-arch-build-for-release:
     runs-on: ubuntu-latest
     steps:
@@ -111,6 +113,7 @@ jobs:
           file: extras/Dockerfile.builder
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          no-cache: true
           tags: |
             docker.io/kadalu/builder:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/builder:latest
@@ -129,6 +132,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
+          no-cache: true
           tags: |
             docker.io/kadalu/kadalu-csi:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-csi:latest
@@ -148,6 +152,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
+          no-cache: true
           tags: |
             docker.io/kadalu/kadalu-server:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-server:latest
@@ -167,6 +172,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           target: prod
           push: true
+          no-cache: true
           tags: |
             docker.io/kadalu/kadalu-operator:${{ steps.vars.outputs.tag }}
             docker.io/kadalu/kadalu-operator:latest

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -6,7 +6,8 @@ ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
 COPY csi-requirements.txt /tmp/
 
-RUN python3 -m pip install -r /tmp/csi-requirements.txt
+RUN python3 -m pip install -r /tmp/csi-requirements.txt && \
+    grep -Po '^[\w\.-]*(?=)' /tmp/csi-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'
 
 FROM python:3.9.6-slim-bullseye as prod
 ENV DEBIAN_FRONTEND=noninteractive

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -19,7 +19,8 @@ RUN apt-get update -yq && \
 
 COPY builder-requirements.txt /tmp/
 RUN python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && \
-    python3 -m pip install -r /tmp/builder-requirements.txt
+    python3 -m pip install -r /tmp/builder-requirements.txt && \
+    grep -Po '^[\w\.-]*(?=)' /tmp/builder-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'
 
 RUN sed -i "s/include-system-site-packages = false/include-system-site-packages = true/g" /kadalu/pyvenv.cfg
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -6,7 +6,8 @@ ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
 COPY operator-requirements.txt /tmp/
 
-RUN python3 -m pip install -r /tmp/operator-requirements.txt
+RUN python3 -m pip install -r /tmp/operator-requirements.txt && \
+    grep -Po '^[\w\.-]*(?=)' /tmp/operator-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'
 
 FROM python:3.9.6-slim-bullseye as prod
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,8 @@ ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
 COPY server-requirements.txt /tmp/
 
-RUN python3 -m pip install -r /tmp/server-requirements.txt
+RUN python3 -m pip install -r /tmp/server-requirements.txt && \
+    grep -Po '^[\w\.-]*(?=)' /tmp/server-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'
 
 FROM python:3.9.6-slim-bullseye as prod
 


### PR DESCRIPTION
Will try to explain in short and concise about the change:

Buildx:
1. Things are simpler if building on an amd64 platform for amd64 image
2. `--platform` and `--load` is must while building images on non amd64 host in `build.sh`
3. `--load` will not work if `--platform` has more than one entry
4. However, `--push` and `--load` work if `--platform` has only one entry and `--load` is used while building
dependent image in the next step to first pull from local docker
5. If `--platform` contains more than one entry, it's mandatory to use `--push`
6. Faulty release for 0.8.5 non amd64 is likely due to existing cache and `no-cache` is set for release CI
7. No way to verify point (6) unless we do an alpha with this PR

Fixes: #633

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>