### PR TITLE
[Obsolete] Remount PVC on nodeplugin reboot

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -10,18 +10,18 @@ import time
 import csi_pb2
 import csi_pb2_grpc
 import grpc
-from kadalulib import CommandException, logf, send_analytics_tracker, execute
+from kadalulib import CommandException, execute, logf, send_analytics_tracker
 from volumeutils import (HOSTVOL_MOUNTDIR, PV_TYPE_SUBVOL, PV_TYPE_VIRTBLOCK,
-                         check_external_volume, create_subdir_volume,
-                         create_block_volume, delete_volume, expand_volume,
+                         check_external_volume, create_block_volume,
+                         create_subdir_volume, delete_volume, expand_volume,
                          get_pv_hosting_volumes, is_hosting_volume_free,
-                         mount_and_select_hosting_volume, search_volume,
-                         unmount_glusterfs, update_free_size,
+                         mount_and_select_hosting_volume, reachable_host,
+                         search_volume, unmount_glusterfs, update_free_size,
                          update_subdir_volume, update_virtblock_volume,
-                         yield_list_of_pvcs, reachable_host)
+                         yield_list_of_pvcs)
 
 VOLINFO_DIR = "/var/lib/gluster"
-KADALU_VERSION = os.environ.get("KADALU_VERSION", "latest")
+KADALU_VERSION = os.environ.get("KADALU_VERSION", "devel")
 
 # Generator to be used in ListVolumes
 GEN = None
@@ -516,8 +516,8 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
 
         entries = [{
             "volume": {
-                "volume_id": value[0],
-                "capacity_bytes": value[1]
+                "volume_id": value.get("name"),
+                "capacity_bytes": value.get("size"),
             }
         } for value in pvcs]
 

--- a/csi/main.py
+++ b/csi/main.py
@@ -6,6 +6,7 @@ import os
 import signal
 import time
 from concurrent import futures
+from pathlib import Path
 
 import csi_pb2_grpc
 import grpc
@@ -52,6 +53,11 @@ def main():
     server.add_insecure_port(os.environ.get("CSI_ENDPOINT", "unix://plugin/csi.sock"))
     logging.info("Server started")
     server.start()
+
+    # Very simple health check that server is started without any issues
+    Path("/tmp").mkdir(parents=True, exist_ok=True)
+    Path("/tmp/health-ok").touch()
+
     try:
         while True:
             time.sleep(_ONE_DAY_IN_SECONDS)

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -150,7 +150,7 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
         update_pv_metadata(*PVC_POOL[request.target_path])
 
         # PVCs count may build-up overtime, so delete the key from global dict
-        del PVC_POOL[request.target_path]
+        PVC_POOL.pop(request.target_path, None)
 
         return csi_pb2.NodeUnpublishVolumeResponse()
 

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -178,6 +178,9 @@ function run_io(){
 
   echo Collecting arequal-checksum from pods under io-pod deployment
   first_sum=$(kubectl exec -i ${pods[0]} -- sh -c 'arequal-checksum /mnt/alpha') && echo "$first_sum"
+
+  # TODO: Reboot nodeplugin
+
   second_sum=$(kubectl exec -i ${pods[1]} -- sh -c 'arequal-checksum /mnt/alpha') && echo "$second_sum"
 
   echo Validate checksum between first and second pod [Empty for checksum match]

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -181,15 +181,8 @@ function run_io(){
 
   # Reboot nodeplugins
   kubectl delete pods -l app.kubernetes.io/name=kadalu-csi-nodeplugin --force
-  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kadalu-csi-nodeplugin --timeout=20s || fail=1
-  nodeplugins=($(kubectl get pods -l app.kubernetes.io/name=kadalu-csi-nodeplugin -o jsonpath={'..metadata.name'}))
-  for pod in $nodeplugins; do
-    for _ in {1..10}; do
-        set +e
-        kubectl exec -it $pod -c kadalu-nodeplugin -- cat /tmp/health-ok 2>/dev/null && break; sleep 2;
-        set -e
-    done
-  done
+  # kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kadalu-csi-nodeplugin --timeout=20s || fail=1
+  sleep 20
 
   second_sum=$(kubectl exec -i ${pods[1]} -- sh -c 'arequal-checksum /mnt/alpha') && echo "$second_sum"
 


### PR DESCRIPTION
Approach:
1. Store minimal data on storage pool to be able to reconstruct target_path on correct node upon nodeplugin reboot
2. Once the nodeplugin reboots, mount all storage pool and search for all PVCs which has target_path
3. Cleanup/unmount damaged mount point and (bind) mount the PVC

Pros:
1. Automatically remount volumes of type 'subdir/virtblock && native' on nodeplugin reboot
2. Separate yaml for operator and nodeplugin isn't needed (it's unaviodable even with separate yaml to not have downtime)

Cons:
1. On nodeplugin reboot, startup time may be noticeable (~2min) before serving requests
2. Extra storage space used on storage pool (increases linearly wrt num of target_paths)
3. Couldn't remount non_native volumes as of now, maybe doable with other approaches

Unknowns:
1. Metadata heal due to usage of `truncate` while updating metadata file?
2. Need to add logic when rawBlock is supported

Alternates (one of):
1. Use kubectl in csi pods as well and query for PVC metadata directly rather than using storage pool
2. Increase the use of k8s python api (it's very less as of now) to get any resource/kind data programatically
3. Create endpoints in operator and serve required data for all other components


Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>