### PR TITLE
Remount PVC on nodeplugin reboot

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -10,18 +10,18 @@ import time
 import csi_pb2
 import csi_pb2_grpc
 import grpc
-from kadalulib import CommandException, logf, send_analytics_tracker, execute
+from kadalulib import CommandException, execute, logf, send_analytics_tracker
 from volumeutils import (HOSTVOL_MOUNTDIR, PV_TYPE_SUBVOL, PV_TYPE_VIRTBLOCK,
-                         check_external_volume, create_subdir_volume,
-                         create_block_volume, delete_volume, expand_volume,
+                         check_external_volume, create_block_volume,
+                         create_subdir_volume, delete_volume, expand_volume,
                          get_pv_hosting_volumes, is_hosting_volume_free,
-                         mount_and_select_hosting_volume, search_volume,
-                         unmount_glusterfs, update_free_size,
+                         mount_and_select_hosting_volume, reachable_host,
+                         search_volume, unmount_glusterfs, update_free_size,
                          update_subdir_volume, update_virtblock_volume,
-                         yield_list_of_pvcs, reachable_host)
+                         yield_list_of_pvcs)
 
 VOLINFO_DIR = "/var/lib/gluster"
-KADALU_VERSION = os.environ.get("KADALU_VERSION", "latest")
+KADALU_VERSION = os.environ.get("KADALU_VERSION", "devel")
 
 # Generator to be used in ListVolumes
 GEN = None

--- a/csi/exporter.py
+++ b/csi/exporter.py
@@ -1,15 +1,13 @@
+import logging
 import os
 import pathlib
 import time
-import logging
 
-from prometheus_client.core import GaugeMetricFamily, \
-     CounterMetricFamily, REGISTRY
+from kadalulib import logf, logging_setup
 from prometheus_client import start_http_server
-
-from volumeutils import (HOSTVOL_MOUNTDIR, PV_TYPE_SUBVOL,
-                         yield_pvc_from_mntdir)
-from kadalulib import logging_setup, logf
+from prometheus_client.core import (REGISTRY, CounterMetricFamily,
+                                    GaugeMetricFamily)
+from volumeutils import HOSTVOL_MOUNTDIR, PV_TYPE_SUBVOL, yield_pvc_from_mntdir
 
 
 class CsiMetricsCollector(object):

--- a/csi/main.py
+++ b/csi/main.py
@@ -3,45 +3,21 @@ Starting point of CSI driver GRP server
 """
 import logging
 import os
-import time
 import signal
-
+import time
 from concurrent import futures
-
-import grpc
+from pathlib import Path
 
 import csi_pb2_grpc
+import grpc
 from controllerserver import ControllerServer
 from identityserver import IdentityServer
-from kadalulib import CommandException, logf, logging_setup
+from kadalulib import logf, logging_setup
 from nodeserver import NodeServer
-from volumeutils import (HOSTVOL_MOUNTDIR, get_pv_hosting_volumes,
-                         mount_glusterfs, reload_glusterfs)
+from volumeutils import (get_pv_hosting_volumes, reload_glusterfs,
+                         remount_storage)
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
-
-def mount_storage():
-    """
-    Mount storage if any volumes exist after a pod reboot
-    """
-    if os.environ.get("CSI_ROLE", "-") != "provisioner":
-        logging.debug("Volume need to be mounted on only provisioner pod")
-        return
-
-    host_volumes = get_pv_hosting_volumes({})
-    for volume in host_volumes:
-        if volume["kformat"] == "non-native":
-            # Need to skip mounting external non-native mounts in-order for
-            # kadalu-quotad not to set quota xattrs
-            continue
-        hvol = volume["name"]
-        mntdir = os.path.join(HOSTVOL_MOUNTDIR, hvol)
-        try:
-            mount_glusterfs(volume, mntdir)
-            logging.info(logf("Volume is mounted successfully", hvol=hvol))
-        except CommandException:
-            logging.error(logf("Unable to mount volume", hvol=hvol))
-    return
 
 
 def reconfigure_mounts(_signum, _frame):
@@ -63,8 +39,9 @@ def main():
     """
     logging_setup()
 
-    # If Provisioner pod reboots, mount volumes if they exist before reboot
-    mount_storage()
+    # If provisioner is rebooted mount storage pool and if nodeplugin is
+    # rebooted mount pvc
+    remount_storage()
 
     signal.signal(signal.SIGHUP, reconfigure_mounts)
 
@@ -76,6 +53,11 @@ def main():
     server.add_insecure_port(os.environ.get("CSI_ENDPOINT", "unix://plugin/csi.sock"))
     logging.info("Server started")
     server.start()
+
+    # Very simple health check that server is started without any issues
+    Path("/tmp").mkdir(parents=True, exist_ok=True)
+    Path("/tmp/health-ok").touch(exist_ok=True)
+
     try:
         while True:
             time.sleep(_ONE_DAY_IN_SECONDS)

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -178,6 +178,12 @@ function run_io(){
 
   echo Collecting arequal-checksum from pods under io-pod deployment
   first_sum=$(kubectl exec -i ${pods[0]} -- sh -c 'arequal-checksum /mnt/alpha') && echo "$first_sum"
+
+  # Reboot nodeplugins
+  kubectl delete pods -l app.kubernetes.io/name=kadalu-csi-nodeplugin --force
+  # kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kadalu-csi-nodeplugin --timeout=20s || fail=1
+  sleep 20
+
   second_sum=$(kubectl exec -i ${pods[1]} -- sh -c 'arequal-checksum /mnt/alpha') && echo "$second_sum"
 
   echo Validate checksum between first and second pod [Empty for checksum match]


### PR DESCRIPTION
- Use `emptyDir` to store temporary data and use that to remount PVC upon nodeplugin reboot

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>