### PR TITLE
Document xfsprogs version requirements

### DIFF
--- a/doc/setup.adoc
+++ b/doc/setup.adoc
@@ -3,7 +3,7 @@
 == Pre-Requisites
 
 - Kubernetes 1.13.0 + version
-- The host should support xfs (`mkfs.xfs`)
+- The host should support xfs (`mkfs.xfs`) with the superblock v5 format
   - On some systems this might require installation of xfsprogs package
 
 == Setup


### PR DESCRIPTION
While testing out the new VirtBlock feature, I initially saw failed mount operations. The Kubelet log contained:

```
mount: /var/lib/kubelet/pods/bfac4377-53ed-4f56-a09b-43bb35ae3437/volumes/kubernetes.io~csi/pvc-8f01e993-0bb0-4960-b564-9fbeb366748f/mount: wrong fs type, bad option, bad superblock on /dev/loop0, missing codepage or helper program, or other error."
```

Digging into things further, I found that the `xfsprogs` package installed on my host machines did not support the superblock v5 format, [as documented here](https://docs.oracle.com/en/operating-systems/oracle-linux/6/relnotes6.9/ol6-rn-issues-xfs-superblock-compat.html). By upgrading the distro on my host machines (and thereby the `xfsprogs` package), I was able to successfully mount VirtBlock PVs.

I wanted to supply stricter version guidance here, but it seems that Redhat-derived distros and Debian-derived distros number their `xfsprogs` packages differently and there doesn't seem to be a way to get consistent version information out of the various CLI utilities without creating an FS and noting what superblock version it used.