### PR TITLE
cli: Add versions of all pods in kadalu-namespace

### DIFF
--- a/cli/kubectl_kadalu/__main__.py
+++ b/cli/kubectl_kadalu/__main__.py
@@ -8,6 +8,7 @@ import sys
 from argparse import ArgumentParser
 
 from version import VERSION
+import utils
 
 # Subcommands list that are currently supported, if any new subcommand has to
 # be implemeted add argument to this list and implement `validate` and `run`
@@ -18,9 +19,8 @@ SUPPORTED_ARGS = [
     "storage-list",
     "storage-remove",
     "logs",
-    "healinfo",
+    "healinfo"
 ]
-
 
 def get_args():
     """Argument Parser"""
@@ -39,9 +39,54 @@ def get_args():
     return parser.parse_args()
 
 
+def get_all_kadalu_pods():
+    """ List of all pods in kadalu namespace """
+
+    try:
+        cmd = ["kubectl", "get", "pods", "-nkadalu", "-oname"]
+        resp = utils.execute(cmd)
+        # Remove empty lines(pod-names) from command response
+        pods = resp.stdout.split()
+        return pods
+    except utils.CommandError as err:
+        utils.command_error(cmd, err.stderr)
+        return None
+
+
+def get_kadalu_version_in_pod(pod):
+    """ Get kadalu version from pods inside kadalu-namespace by exec """
+
+    try:
+
+        cmd = ["kubectl", "exec", "-nkadalu", pod, "--", "bash",
+                "-c", "echo $KADALU_VERSION"]
+
+        if "nodeplugin" in pod or "provisioner" in pod:
+            version_container = "kadalu-nodeplugin"
+            if "provisioner" in pod:
+                version_container = "kadalu-provisioner"
+            cmd.insert(3, "-c")
+            cmd.insert(4, version_container)
+
+        version_resp = utils.execute(cmd)
+        version = version_resp.stdout.strip()
+
+        return version
+
+    except utils.CommandError as err:
+        utils.command_error(cmd, err.stderr)
+        return None
+
+
 def show_version():
     """Show version information"""
-    print("kubectl-kadalu %s" % VERSION)
+    print("kubectl-kadalu plugin: %s" % VERSION)
+    pods = get_all_kadalu_pods()
+    if pods:
+        print("kadalu pod(s) versions")
+        for pod in pods:
+            version = get_kadalu_version_in_pod(pod)
+            print("%s: %s" %(pod, version))
 
 
 def version_set_args(name, parser):

--- a/cli/kubectl_kadalu/logs.py
+++ b/cli/kubectl_kadalu/logs.py
@@ -26,13 +26,13 @@ def set_args(name, subparsers):
 
     arg("-c",
         "--container",
-        help="Specify container name to get log info.\n"
+        help="Specify the container name to get log info.\n"
         "To be used along with '--podname'")
 
     arg("-A",
         "--allcontainers",
         action="store_true",
-        help=("Show logs of all containers"
+        help=("Show logs of all containers "
               "of a particular pod.\n"
               "To be used along with '--podname'"))
 


### PR DESCRIPTION
This PR adds versions of all pods managed by kadalu,
by exec into them. Helps while debugging for version
related errors.

Fixes: #675 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>