### PR TITLE
Add extendend heal info , fixes kadalu/kadalu#684

### DIFF
--- a/csi/heal-info.sh
+++ b/csi/heal-info.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 MOUNT_DIR=/mnt
 
 if [ $# -eq 1 ]; then

--- a/csi/heal-info.sh
+++ b/csi/heal-info.sh
@@ -30,4 +30,5 @@ for volfile in $(cd /kadalu/volfiles; ls *); do
     vol=${volfile%.client.vol}
     echo "Giving heal information of volume $vol"
     /opt/libexec/glusterfs/glfsheal $vol info-summary volfile-path /kadalu/volfiles/$volfile
+    echo
 done

--- a/csi/heal-info.sh
+++ b/csi/heal-info.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 MOUNT_DIR=/mnt
 
 if [ $# -eq 1 ]; then
@@ -28,7 +29,19 @@ fi
 for volfile in $(cd /kadalu/volfiles; ls *); do
     #/opt/libexec/glusterfs/glfsheal <VOLNAME> [bigger-file <FILE> | latest-mtime <FILE> | source-brick <HOSTNAME:BRICKNAME> [<FILE>] | split-brain-info | info-summary] [glusterd-sock <FILE> | volfile-path <FILE>]
     vol=${volfile%.client.vol}
-    echo "Giving heal information of volume $vol"
-    /opt/libexec/glusterfs/glfsheal $vol info-summary volfile-path /kadalu/volfiles/$volfile
+    echo "Giving heal summary of volume ${vol}:"
+    # Storing the output of the info-summary for later evaluation
+    result=$(/opt/libexec/glusterfs/glfsheal $vol info-summary volfile-path /kadalu/volfiles/$volfile )
+    echo "$result"
     echo
+    # If info-summary has only "0" or "-" our exit code is "1" and we skip checking for heal details/split-brain
+    echo "$result" | grep "Total Number of entries" | cut -d ":" -f 2 |  grep -q -vE "0|-"
+    if [ "$?" -eq 0 ]; then
+	    echo "List of files needing a heal on ${vol}:"
+            /opt/libexec/glusterfs/glfsheal $vol volfile-path /kadalu/volfiles/$volfile
+	    echo
+	    echo "List of files in splitbrain on ${vol}:"
+            /opt/libexec/glusterfs/glfsheal $vol split-brain-info volfile-path /kadalu/volfiles/$volfile
+    fi
+    echo;echo
 done


### PR DESCRIPTION
It seems that we need extended info only when total entries from info-summary is greater than 0 and is not "-" (replica 2).