### PR TITLE
healinfo: Trigger client-side heal

### DIFF
--- a/cli/kubectl_kadalu/healinfo.py
+++ b/cli/kubectl_kadalu/healinfo.py
@@ -13,6 +13,13 @@ def set_args(name, subparsers):
     """ add arguments to argparser """
     # TODO: allow check of specific storage pool
     parser = subparsers.add_parser(name)
+    arg = parser.add_argument
+
+    arg("--trigger-full-heal",
+        action="store_true",
+        help="Trigger full client side self heal on all volumes"
+    )
+
     utils.add_global_flags(parser)
 
 
@@ -25,12 +32,15 @@ def run(args):
     """ perform log subcommand """
 
     try:
-        cmd = utils.kubectl_cmd(args) + ["exec",
-                                         "-nkadalu",
-                                         "kadalu-csi-provisioner-0",
-                                         "-c",
-                                         "kadalu-provisioner",
-                                         "--", "/kadalu/heal-info.sh"]
+        heal_info_cmd = ["exec",
+                        "-nkadalu",
+                        "kadalu-csi-provisioner-0",
+                        "-c",
+                        "kadalu-provisioner",
+                        "--", "/kadalu/heal-info.sh"]
+        if args.trigger_full_heal:
+            heal_info_cmd.append("trigger_full_heal")
+        cmd = utils.kubectl_cmd(args) + heal_info_cmd
         resp = utils.execute(cmd)
         print(resp.stdout)
         print()

--- a/csi/heal-info.sh
+++ b/csi/heal-info.sh
@@ -2,6 +2,19 @@
 
 MOUNT_DIR=/mnt
 
+declare -a arr=("$@")
+for i in "${arr[@]}"; do
+    if [[ $i == "trigger_full_heal" ]]; then
+        # Apply full client-side heal on all available volumes if volume is not specified
+        for volfile in $(cd /kadalu/volfiles; ls *); do
+            vol=${volfile%.client.vol}
+            echo "Applying full client-side self-heal on volume ${vol} by crawling recursively:"
+            find /mnt/* -type f -follow -print
+            exit 0
+        done
+    fi
+done
+
 if [ $# -eq 1 ]; then
     dir=$1
     if [ -f /kadalu/volfiles/$dir.client.vol ]; then
@@ -13,7 +26,7 @@ if [ $# -eq 1 ]; then
 fi
 
 if [ $# -gt 1 ]; then
-    echo "Expects zero or one options"
+    echo "Expects atmost one option"
     exit 1;
 fi
 


### PR DESCRIPTION
This PR scrawls through all available volume dirs to trigger client side full heal.
Used this method since "full" option is not available in "glfheal" binary at /opt/glusterfs.
Have added "--trigger-full-heal" option to heal all volumes for now. Will add option to support
heal and heal-info on individual volumes with a separate PR.

Updates: #684
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>