### PR TITLE
krew: Set job for auto update of kadalu plugin at krew-index

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -71,6 +71,10 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
+    - name: Update new version for plugin "kadalu" in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.40
+      with:
+        krew_template_file: krew/kadalu.yaml
 
   # Use no-cache while building images as they may break release and they are built
   # only during release so the delay/bandwidth worth the time

--- a/krew/krew.yaml
+++ b/krew/krew.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kadalu
 spec:
-  version: "v0.8.7"
+  version: {{ .TagName }}
   homepage: https://github.com/kadalu/kadalu
   shortDescription: "Deploy and manage Kadalu Operator, CSI and Storage pods"
   description: |
@@ -21,6 +21,10 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/kadalu/kadalu/releases/download/0.8.7/kubectl-kadalu.tar.gz
-    sha256: d0d754d6e4e08f7a09f25913bf787e9da5944488b7f630cc57d99655dc2b242b
+    {{addURIAndSha "https://github.com/kadalu/kadalu/releases/download/{{ .TagName }}/kubectl-kadalu.tar.gz" .TagName }}
     bin: kubectl-kadalu
+    files:
+    - from: kubectl-kadalu
+      to: .
+    - from: LICENSE
+      to: .


### PR DESCRIPTION
Now that "kadalu" plugin has been added to "kubernetes-sigs/krew-index" repo,
need to set up GH Job for auto update by sending PR's with version and sha256sum changes,
to "krew-index" upstream repo.
Documentation referred:
[krew-release-bot](https://github.com/rajatjindal/krew-release-bot ) & [release-automating-updates](https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/)

Updates: #511 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.io>