### PR TITLE
cli: Alternate syntax for Storage Pool add

### DIFF
--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -58,10 +58,20 @@ jobs:
       COMMIT_MSG: ${{needs.get-info.outputs.msg}}
       FILES: ${{needs.get-info.outputs.files}}
     steps:
-    # Build Containers
     - uses: actions/checkout@v2
     - name: Install Docker Dependencies
-      run: sudo apt-get install -y conntrack
+      run: sudo apt-get install -y conntrack ruby
+    # CLI Tests
+    - name: Install Binnacle and build kubectl-kadalu
+      run: |
+        curl -L https://github.com/kadalu/binnacle/releases/latest/download/binnacle -o binnacle
+        chmod +x ./binnacle
+        sudo mv ./binnacle /usr/local/bin/binnacle
+        binnacle --version
+        make cli-build
+    - name: kubectl-kadalu Tests
+      run: binnacle -v cli/tests/storage_add.t
+    # Build Containers
     - name: Build locally
       id: build_local
       run: |

--- a/cli/kubectl_kadalu/storage_add_parser.py
+++ b/cli/kubectl_kadalu/storage_add_parser.py
@@ -1,0 +1,351 @@
+"""
+Storage Add alternate syntax parser
+"""
+TYPE_KEYWORD = 0
+NUMBER = 1
+STORAGE_UNIT = 2
+
+TYPE_KEYWORDS = [
+    "replica",
+    "mirror",
+    "disperse",
+    "disperse-data",
+    "redundancy",
+    "arbiter",
+    "external"
+]
+
+
+class InvalidVolumeCreateRequest(Exception):
+    """Raise when the Volume Create request is not valid"""
+
+
+
+# noqa # pylint: disable=too-few-public-methods
+class Token:
+    """Token Structure"""
+    def __init__(self, kind, value):
+        self.kind = kind
+        self.value = value
+
+
+# noqa # pylint: disable=too-few-public-methods
+class VolumeCreateRequest:
+    """Volume Create Request"""
+    def __init__(self):
+        self.distribute_groups = []
+
+
+# noqa # pylint: disable=too-few-public-methods
+class VolumeCreateRequestDistributeGroup:
+    """Distribute Group"""
+    def __init__(self):
+        self.storage_units = []
+        self.replica_count = 0
+        self.arbiter_count = 0
+        self.disperse_count = 0
+        self.redundancy_count = 0
+        self.external_count = 0
+        self.replica_keyword = ""
+
+
+def next_token(tokens):
+    """Get next item from the iterator else return None"""
+    try:
+        return next(tokens)
+    except StopIteration:
+        return None
+
+
+def tokenizer(args):
+    """
+    Split input arguments into Tokens.
+    """
+    tokens = []
+
+    for arg in args:
+        if arg in TYPE_KEYWORDS:
+            tokens.append(Token(TYPE_KEYWORD, arg))
+            continue
+
+        try:
+            int(arg)
+            tokens.append(Token(NUMBER, arg))
+            continue
+        except ValueError:
+            pass
+
+        tokens.append(Token(STORAGE_UNIT, arg))
+
+    return tokens
+
+
+def disperse_and_redundancy_count(disperse, data, redundancy):
+    """
+    Any two counts available out of three, return
+    only normalized disperse and redundancy count.
+    """
+    if data > 0 and redundancy > 0:
+        return (data + redundancy, redundancy)
+
+    if data > 0 and disperse > 0:
+        return (disperse, disperse - data)
+
+    return (disperse, redundancy)
+
+
+def get_subvol_size(counts):
+    """
+    Count based grouping when storage units list is provided as
+    separate list and count is specified with the keyword.
+    For example: `replica 3 H1:S1 H2:S2 H3:S3 H4:S4 H5:S5 H6:S6`
+    """
+    if counts["replica"] > 0 or counts["mirror"] > 0:
+        return counts["replica"] + counts["mirror"] + counts["arbiter"]
+
+    if counts["disperse"] > 0 or counts["disperse-data"] > 0 or \
+       counts["redundancy"] > 0:
+        disp_count, _ = disperse_and_redundancy_count(
+            counts["disperse"],
+            counts["disperse-data"],
+            counts["redundancy"]
+        )
+        return disp_count
+
+    return 1
+
+
+def split_list(storage_units, subvol_size):
+    """Split the list of Storage units based on Subvol size"""
+    for idx in range(0, len(storage_units), subvol_size):
+        yield storage_units[idx:idx + subvol_size]
+
+
+def replica_keyword(replica_count, mirror_count):
+    """Replica volume can be created using `replica` or `mirror` keyword."""
+    if replica_count > 0:
+        return "replica"
+
+    if mirror_count > 0:
+        return "mirror"
+
+    return ""
+
+
+def distribute_group_count_based(counts, storage_units):
+    """
+    Split the given storage units into list of distribute
+    groups based on replica/disperse count.
+    """
+    subvol_size = get_subvol_size(counts)
+    for grp_storage_units in split_list(storage_units, subvol_size):
+        dist_group = VolumeCreateRequestDistributeGroup()
+        dist_group.storage_units = grp_storage_units
+        dist_group.replica_count = counts["replica"] + counts["mirror"]
+        dist_group.arbiter_count = counts["arbiter"]
+        dist_group.disperse_count, dist_group.redundancy_count = \
+            disperse_and_redundancy_count(
+                counts["disperse"],
+                counts["disperse-data"],
+                counts["redundancy"]
+            )
+        dist_group.replica_keyword = replica_keyword(
+            counts["replica"],
+            counts["mirror"]
+        )
+        yield dist_group
+
+
+def different_type_exists(storage_units, current_keyword):
+    """
+    If one type of distribute group is already parsed, it is
+    now time to start new distribute group. Return true if a
+    different type of distribute group already exists.
+    """
+    if current_keyword in ["replica", "mirror", "arbiter"]:
+        disperse_related_count = len(storage_units["disperse"]) + \
+            len(storage_units["redundancy"]) + \
+            len(storage_units["disperse-data"])
+
+        if disperse_related_count > 0:
+            return True
+
+    if current_keyword in ["disperse", "disperse-data", "redundancy"]:
+        replica_related_count = len(storage_units["replica"]) + \
+            len(storage_units["mirror"]) + len(storage_units["arbiter"])
+
+        if replica_related_count > 0:
+            return True
+
+    return False
+
+
+def distribute_group(storage_units, current_keyword):
+    """
+    When parser encounters the type keyword or at the end of the
+    parsing, find out one distribute group is already parsed or not.
+    Return None if parsing of a distribute group is not complete else
+    return the distribute group object.
+    """
+    if current_keyword is not None and \
+       len(storage_units[current_keyword]) == 0 and \
+       not different_type_exists(storage_units, current_keyword):
+        return None
+
+    dist_group = VolumeCreateRequestDistributeGroup()
+
+    if current_keyword is None and len(storage_units["external"]) > 0:
+        dist_group.storage_units = storage_units["external"]
+        dist_group.external_count = len(storage_units["external"])
+    elif len(storage_units["replica"]) > 0 or len(storage_units["mirror"]) > 0:
+        dist_group.storage_units = storage_units["replica"] + \
+            storage_units["mirror"] + storage_units["arbiter"]
+        dist_group.replica_count = len(storage_units["replica"]) + \
+            len(storage_units["mirror"])
+        dist_group.arbiter_count = len(storage_units["arbiter"])
+        dist_group.replica_keyword = replica_keyword(
+            len(storage_units["replica"]),
+            len(storage_units["mirror"])
+        )
+    elif len(storage_units["disperse"]) > 0 or \
+         len(storage_units["disperse-data"]) > 0:
+        dist_group.storage_units = storage_units["disperse"] + \
+            storage_units["disperse-data"] + storage_units["redundancy"]
+        dist_group.disperse_count, dist_group.redundancy_count = \
+            disperse_and_redundancy_count(
+                len(storage_units["disperse"]),
+                len(storage_units["disperse-data"]),
+                len(storage_units["redundancy"])
+            )
+    else:
+        return None
+
+    return dist_group
+
+
+def reset_storage_units():
+    """
+    Reset the Storage units object before parsing
+    each distribute group
+    """
+    return {
+        "replica": [],
+        "mirror": [],
+        "arbiter": [],
+        "disperse": [],
+        "disperse-data": [],
+        "redundancy": [],
+        "external": []
+    }
+
+
+# noqa # pylint: disable=too-many-branches
+def parser(tokens):
+    """
+    Parse each tokens and construct the Volume Create Request
+    """
+    req = VolumeCreateRequest()
+    tokens_iter = iter(tokens)
+    token = next_token(tokens_iter)
+
+    counts = {
+        "replica": 0,
+        "mirror": 0,
+        "arbiter": 0,
+        "disperse": 0,
+        "disperse-data": 0,
+        "redundancy": 0
+    }
+    storage_units = reset_storage_units()
+    all_storage_units = []
+    skip_token_next = False
+
+    while True:
+        if token is None:
+            break
+
+        if token.kind == TYPE_KEYWORD:
+            keyword = token.value
+            dist_group = distribute_group(storage_units, keyword)
+            if dist_group is not None:
+                req.distribute_groups.append(dist_group)
+                storage_units = reset_storage_units()
+
+            while True:
+                token = next_token(tokens_iter)
+
+                if token is None:
+                    break
+
+                if token.kind == STORAGE_UNIT:
+                    storage_units[keyword].append(token.value)
+                    continue
+
+                if token.kind == NUMBER:
+                    counts[keyword] = int(token.value)
+                else:
+                    skip_token_next = True
+
+                break
+        elif token.kind == STORAGE_UNIT:
+            all_storage_units.append(token.value)
+
+        if not skip_token_next:
+            skip_token_next = False
+            token = next_token(tokens_iter)
+
+    dist_group = distribute_group(storage_units, None)
+    if dist_group is not None:
+        req.distribute_groups.append(dist_group)
+
+    if len(all_storage_units) > 0:
+        req.distribute_groups = list(distribute_group_count_based(
+            counts, all_storage_units
+        ))
+
+    return req
+
+
+def validate(req):
+    """
+    Validate the Volume create request after parsing
+    """
+    for dist_grp in req.distribute_groups:
+        if dist_grp.replica_count > 0 and \
+           len(dist_grp.storage_units) != dist_grp.replica_count:
+            raise InvalidVolumeCreateRequest(
+                "Number of Storage units not matching "
+                f"{dist_grp.replica_keyword} count"
+            )
+        if dist_grp.disperse_count > 0 and \
+           len(dist_grp.storage_units) != dist_grp.disperse_count:
+            raise InvalidVolumeCreateRequest(
+                "Number of Storage units not matching disperse count"
+            )
+
+
+def volume_type(req):
+    """Find Volume Type based on the first distribute Group"""
+    dist_grp_1 = req.distribute_groups[0]
+    if dist_grp_1.replica_count == 2:
+        return "Replica2"
+
+    if dist_grp_1.replica_count == 3:
+        return "Replica3"
+
+    if dist_grp_1.disperse_count == 3:
+        return "Disperse"
+
+    if dist_grp_1.external_count > 0:
+        return "External"
+
+    return "Replica1"
+
+
+def get_all_storage_units(req):
+    """Return only the list of Storage Units from the request"""
+    storage_units = []
+    for dist_grp in req.distribute_groups:
+        storage_units += dist_grp.storage_units
+
+    return storage_units

--- a/cli/tests/storage_add.t
+++ b/cli/tests/storage_add.t
@@ -1,0 +1,814 @@
+cmd = "python3 cli/kubectl_kadalu"
+
+def diff(expected, actual)
+  "Expected:\n#{expected}\n\nActual:\n#{actual}\n"
+end
+
+def EQUAL(expected, actual, desc)
+  TRUE expected == actual, desc, diff(expected, actual)
+end
+
+# External Storage Pool
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "External"
+  storage: []
+  details:
+    gluster_hosts: ['server1.example.com']
+    gluster_volname: "exports/sp1/s1"
+    gluster_options: ""
+
+)
+actual = TEST "#{cmd} storage-add --dry-run sp1 external server1.example.com:/exports/sp1/s1"
+EQUAL expected, actual, "external as keyword"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --external server1.example.com:/exports/sp1/s1"
+EQUAL expected, actual, "with --external flag"
+
+# Replica1 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --path server1.example.com:/exports/sp1/s1"
+EQUAL expected, actual, "Auto Replica1 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --path server1.example.com:/exports/sp1/s1"
+EQUAL expected, actual, "Replica1 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 server1.example.com:/exports/sp1/s1 --storage-unit-type=path"
+EQUAL expected, actual, "Auto Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 --storage-unit-type=path"
+EQUAL expected, actual, "Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 server1.example.com:/exports/sp1/s1 --storage-unit-type=path"
+EQUAL expected, actual, "Replica1 with alternate syntax 2 and --storage-unit-type=path"
+
+# Replica1 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - pvc: "pvc1"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --pvc pvc1"
+EQUAL expected, actual, "Auto Replica1 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --pvc pvc1"
+EQUAL expected, actual, "Replica1 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 pvc1 --storage-unit-type=pvc"
+EQUAL expected, actual, "Auto Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica1 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 pvc1 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica1 with alternate syntax 2 and --storage-unit-type=pvc"
+
+# Replica1 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --device server1.example.com:/dev/vdc"
+EQUAL expected, actual, "Auto Replica1 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --device server1.example.com:/dev/vdc"
+EQUAL expected, actual, "Replica1 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 server1.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Auto Replica1 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica1 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 server1.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica1 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica2 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2"
+EQUAL expected, actual, "Replica2 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 --storage-unit-type=path"
+EQUAL expected, actual, "Replica2 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 --storage-unit-type=path"
+EQUAL expected, actual, "Replica2 with alternate syntax 2 and --storage-unit-type=path"
+
+# Replica2 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc"
+EQUAL expected, actual, "Replica2 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc server2.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica2 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 server1.example.com:/dev/vdc server2.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica2 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica2 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --pvc pvc1 --pvc pvc2"
+EQUAL expected, actual, "Replica2 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 pvc2 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica2 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 pvc1 pvc2 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica2 with alternate syntax 2 and --storage-unit-type=pvc"
+
+
+# Replica3 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+    - node: "server3.example.com"
+      path: "/exports/sp1/s3"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2 --path server3.example.com:/exports/sp1/s3"
+EQUAL expected, actual, "Replica3 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Replica3 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Replica3 with alternate syntax 2 and --storage-unit-type=path"
+
+# Replica3 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+    - node: "server3.example.com"
+      device: "/dev/vdc"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc --device server3.example.com:/dev/vdc"
+EQUAL expected, actual, "Replica3 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica3 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Replica3 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica3 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --pvc pvc1 --pvc pvc2 --pvc pvc3"
+EQUAL expected, actual, "Replica3 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 pvc2 pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica3 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 pvc1 pvc2 pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Replica3 with alternate syntax 2 and --storage-unit-type=pvc"
+
+
+# Disperse with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+    - node: "server3.example.com"
+      path: "/exports/sp1/s3"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2 --path server3.example.com:/exports/sp1/s3"
+EQUAL expected, actual, "Disperse with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 redundancy server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Disperse with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 --storage-unit-type=path"
+EQUAL expected, actual, "Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=path"
+
+
+# Disperse with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+    - node: "server3.example.com"
+      device: "/dev/vdc"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc --device server3.example.com:/dev/vdc"
+EQUAL expected, actual, "Disperse with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data server1.example.com:/dev/vdc server2.example.com:/dev/vdc redundancy server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Disperse with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=device"
+
+# Disperse with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --pvc pvc1 --pvc pvc2 --pvc pvc3"
+EQUAL expected, actual, "Disperse with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data pvc1 pvc2 redundancy pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Disperse with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 pvc1 pvc2 pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 pvc1 pvc2 pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 pvc1 pvc2 pvc3 --storage-unit-type=pvc"
+EQUAL expected, actual, "Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=pvc"
+
+# Distributed Storage Pool tests
+# Distributed Replica1 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2"
+EQUAL expected, actual, "Auto Distributed Replica1 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2"
+EQUAL expected, actual, "Distributed Replica1 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 --storage-unit-type=path"
+EQUAL expected, actual, "Auto Distributed Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 replica server2.example.com:/exports/sp1/s2 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax 2 and --storage-unit-type=path"
+
+# Distributed Replica1 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --pvc pvc1 --pvc pvc2"
+EQUAL expected, actual, "Auto Distributed Replica1 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --pvc pvc1 --pvc pvc2"
+EQUAL expected, actual, "Distributed Replica1 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 pvc1 pvc2 --storage-unit-type=pvc"
+EQUAL expected, actual, "Auto Distributed Replica1 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 replica pvc2 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 pvc1 pvc2 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax 2 and --storage-unit-type=pvc"
+
+# Distributed Replica1 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica1"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc"
+EQUAL expected, actual, "Auto Distributed Replica1 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica1 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc"
+EQUAL expected, actual, "Distributed Replica1 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Auto Replica1 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc replica server2.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica1 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica2 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+    - node: "server3.example.com"
+      path: "/exports/sp1/s3"
+    - node: "server4.example.com"
+      path: "/exports/sp1/s4"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2 --path server3.example.com:/exports/sp1/s3 --path server4.example.com:/exports/sp1/s4"
+EQUAL expected, actual, "Distributed Replica2 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 replica server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax 2 and --storage-unit-type=path"
+
+# Replica2 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+    - node: "server3.example.com"
+      device: "/dev/vdc"
+    - node: "server4.example.com"
+      device: "/dev/vdc"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc --device server3.example.com:/dev/vdc --device server4.example.com:/dev/vdc"
+EQUAL expected, actual, "Distributed Replica2 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc server2.example.com:/dev/vdc replica server3.example.com:/dev/vdc server4.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica2 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+    - pvc: "pvc4"
+  tiebreaker:
+    node: "tie-breaker.kadalu.io"
+    path: "/mnt"
+    port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --pvc pvc1 --pvc pvc2 --pvc pvc3 --pvc pvc4"
+EQUAL expected, actual, "Distributed Replica2 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 pvc2 replica pvc3 pvc4 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 pvc1 pvc2 pvc3 pvc4 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica2 with alternate syntax 2 and --storage-unit-type=pvc"
+
+# Replica3 with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+    - node: "server3.example.com"
+      path: "/exports/sp1/s3"
+    - node: "server4.example.com"
+      path: "/exports/sp1/s4"
+    - node: "server5.example.com"
+      path: "/exports/sp1/s5"
+    - node: "server6.example.com"
+      path: "/exports/sp1/s6"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2 --path server3.example.com:/exports/sp1/s3 --path server4.example.com:/exports/sp1/s4 --path server5.example.com:/exports/sp1/s5 --path server6.example.com:/exports/sp1/s6"
+EQUAL expected, actual, "Distributed Replica3 with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 replica server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax 2 and --storage-unit-type=path"
+
+# Replica3 with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+    - node: "server3.example.com"
+      device: "/dev/vdc"
+    - node: "server4.example.com"
+      device: "/dev/vdc"
+    - node: "server5.example.com"
+      device: "/dev/vdc"
+    - node: "server6.example.com"
+      device: "/dev/vdc"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc --device server3.example.com:/dev/vdc --device server4.example.com:/dev/vdc --device server5.example.com:/dev/vdc --device server6.example.com:/dev/vdc"
+EQUAL expected, actual, "Distributed Replica3 with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc replica server4.example.com:/dev/vdc server5.example.com:/dev/vdc server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc server5.example.com:/dev/vdc server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax 2 and --storage-unit-type=device"
+
+# Replica3 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica3"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+    - pvc: "pvc4"
+    - pvc: "pvc5"
+    - pvc: "pvc6"
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica3 --pvc pvc1 --pvc pvc2 --pvc pvc3 --pvc pvc4 --pvc pvc5 --pvc pvc6"
+EQUAL expected, actual, "Distributed Replica3 with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica pvc1 pvc2 pvc3 replica pvc4 pvc5 pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 replica 3 pvc1 pvc2 pvc3 pvc4 pvc5 pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Replica3 with alternate syntax 2 and --storage-unit-type=pvc"
+
+
+# Distributed Disperse with path
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - node: "server1.example.com"
+      path: "/exports/sp1/s1"
+    - node: "server2.example.com"
+      path: "/exports/sp1/s2"
+    - node: "server3.example.com"
+      path: "/exports/sp1/s3"
+    - node: "server4.example.com"
+      path: "/exports/sp1/s4"
+    - node: "server5.example.com"
+      path: "/exports/sp1/s5"
+    - node: "server6.example.com"
+      path: "/exports/sp1/s6"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --path server1.example.com:/exports/sp1/s1 --path server2.example.com:/exports/sp1/s2 --path server3.example.com:/exports/sp1/s3 --path server4.example.com:/exports/sp1/s4 --path server5.example.com:/exports/sp1/s5 --path server6.example.com:/exports/sp1/s6"
+EQUAL expected, actual, "Distributed Disperse with --path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 redundancy server3.example.com:/exports/sp1/s3 disperse-data server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 redundancy server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Disperse with alternate syntax and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=path"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 server1.example.com:/exports/sp1/s1 server2.example.com:/exports/sp1/s2 server3.example.com:/exports/sp1/s3 server4.example.com:/exports/sp1/s4 server5.example.com:/exports/sp1/s5 server6.example.com:/exports/sp1/s6 --storage-unit-type=path"
+EQUAL expected, actual, "Distributed Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=path"
+
+
+# Distributed Disperse with device
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - node: "server1.example.com"
+      device: "/dev/vdc"
+    - node: "server2.example.com"
+      device: "/dev/vdc"
+    - node: "server3.example.com"
+      device: "/dev/vdc"
+    - node: "server4.example.com"
+      device: "/dev/vdc"
+    - node: "server5.example.com"
+      device: "/dev/vdc"
+    - node: "server6.example.com"
+      device: "/dev/vdc"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --device server1.example.com:/dev/vdc --device server2.example.com:/dev/vdc --device server3.example.com:/dev/vdc --device server4.example.com:/dev/vdc --device server5.example.com:/dev/vdc --device server6.example.com:/dev/vdc"
+EQUAL expected, actual, "Distributed Disperse with --device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data server1.example.com:/dev/vdc server2.example.com:/dev/vdc redundancy server3.example.com:/dev/vdc disperse-data server4.example.com:/dev/vdc server5.example.com:/dev/vdc redundancy server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Disperse with alternate syntax and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc server5.example.com:/dev/vdc server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc server5.example.com:/dev/vdc server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=device"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc server5.example.com:/dev/vdc server6.example.com:/dev/vdc --storage-unit-type=device"
+EQUAL expected, actual, "Distributed Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=device"
+
+# Disperse with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Disperse"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+    - pvc: "pvc4"
+    - pvc: "pvc5"
+    - pvc: "pvc6"
+  disperse:
+    data: 2
+    redundancy: 1
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Disperse --data 2 --redundancy 1 --pvc pvc1 --pvc pvc2 --pvc pvc3 --pvc pvc4 --pvc pvc5 --pvc pvc6"
+EQUAL expected, actual, "Distributed Disperse with --pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data pvc1 pvc2 redundancy pvc3 disperse-data pvc4 pvc5 redundancy pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Disperse with alternate syntax and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 redundancy 1 pvc1 pvc2 pvc3 pvc4 pvc5 pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Disperse(disperse & redundancy) with alternate syntax 2 and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse-data 2 redundancy 1 pvc1 pvc2 pvc3 pvc4 pvc5 pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Disperse(disperse-data & redundancy) with alternate syntax 2 and --storage-unit-type=pvc"
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 disperse 3 disperse-data 2 pvc1 pvc2 pvc3 pvc4 pvc5 pvc6 --storage-unit-type=pvc"
+EQUAL expected, actual, "Distributed Disperse(disperse & disperse-data) with alternate syntax 2 and --storage-unit-type=pvc"


### PR DESCRIPTION
Distributed Replica3:

Existing

```
kubectl kadalu storage-add sp1 --type=Replica3 \
    --path server1.example.com:/exports/sp1/s1 \
    --path server2.example.com:/exports/sp1/s2 \
    --path server3.example.com:/exports/sp1/s3 \
    --path server4.example.com:/exports/sp1/s4 \
    --path server5.example.com:/exports/sp1/s5 \
    --path server6.example.com:/exports/sp1/s6
```

Alternate 1

```
kubectl kadalu storage-add sp1 --storage-unit-type=path \
    replica server1.example.com:/exports/sp1/s1 \
            server2.example.com:/exports/sp1/s2 \
            server3.example.com:/exports/sp1/s3 \
    replica server4.example.com:/exports/sp1/s4 \
            server5.example.com:/exports/sp1/s5 \
            server6.example.com:/exports/sp1/s6
```

Alternate 2

```
kubectl kadalu storage-add sp1 --storage-unit-type=path \
    replica 3 \
    server1.example.com:/exports/sp1/s1 \
    server2.example.com:/exports/sp1/s2 \
    server3.example.com:/exports/sp1/s3 \
    server4.example.com:/exports/sp1/s4 \
    server5.example.com:/exports/sp1/s5 \
    server6.example.com:/exports/sp1/s6
```

Fixes: #548
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>