### PR TITLE
Fix kadalu-info ConfigMap on-update reload

### DIFF
--- a/csi/watch-vol-changes.sh
+++ b/csi/watch-vol-changes.sh
@@ -6,19 +6,19 @@
 # the pod.
 
 # ConfigMap dir as per csi.yaml pod's template.
-CONFIG_MAP_DIR="/var/lib/gluster"
+CONFIG_MAP_DIR="/var/lib/gluster/..data"
 
 # Currently 'SIGHUP' handling is done only in 'csi/main.py'.
-CSI_PROCESS_ID=$(ps aux|grep python | grep main | awk '{ print $2}' | xargs);
+CSI_PROCESS_ID="$(pgrep -f '^python3.*main.py$')";
 
 echo "Starting watch on configmap"
 while true; do
     # Starting inotifywait without `-m` option (ie, `--monitor`), which makes the process
     # exit after first instance of modify on directory.
-    line=$(inotifywait -e modify ${CONFIG_MAP_DIR});
+    line="$(inotifywait -e modify ${CONFIG_MAP_DIR})";
     # Send a blanket HUP, so all vols can be checked and relevant glusterfs process can be sent a SIGHUP after volgen
-    echo $line
-    kill -HUP $CSI_PROESS_ID;
+    echo "Catched update on kadalu-info CM: $line"
+    kill -HUP "$CSI_PROCESS_ID";
 done
 
 echo "Exiting..."


### PR DESCRIPTION
Following the discussion in the related issue (#714) this PR proposes one of the possible solutions to address kadalu-info on-update reload.
The proposed solution is based on establishing the inode watchers on `/var/lib/gluster/..data` instead of `/var/lib/gluster`, another possible solution is to establish said watchers recursively on `/var/lib/gluster`

Tested on:
- k8s v1.20.12
- k3s v1.22.3+k3s1

Fixes: #714 