### PR TITLE
Additional check in ControllerExpandVolume

### DIFF
--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -598,6 +598,16 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
 
         # Get existing volume
         existing_volume = search_volume(request.volume_id)
+        if not existing_volume:
+            errmsg = logf(
+                "Unable to find volume",
+                volume_id=request.volume_id
+            )
+            logging.error(errmsg)
+            context.set_details(str(errmsg))
+            context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
+            return csi_pb2.ControllerExpandVolumeResponse()
+
         if existing_volume.extra['kformat'] == 'non-native':
             errmsg = "PV with kadalu_format == non-native doesn't support Expansion"
             logging.error(errmsg)


### PR DESCRIPTION
```
[2021-11-30 12:35:03,954] ERROR [main - 42:mount_storage] - Unable to mount volume       hvol=out-dev-gluster
[2021-11-30 12:35:03,962] INFO [main - 76:main] - Server started
[2021-11-30 12:35:04,787] ERROR [_server - 454:_call_behavior] - Exception calling application: 'NoneType' object has no attribute 'extra'
Traceback (most recent call last):
  File "/kadalu/lib/python3.9/site-packages/grpc/_server.py", line 444, in _call_behavior
    response_or_iterator = behavior(argument, context)
  File "/kadalu/controllerserver.py", line 601, in ControllerExpandVolume
    if existing_volume.extra['kformat'] == 'non-native':
```