### PR TITLE
Multiple fixes for External mount

### DIFF
--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -93,12 +93,11 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
         if voltype == "External":
             logging.debug(logf(
                 "Mounted Volume for PV",
-                volume=request.volume_id,
+                volume=volume,
                 mntdir=mntdir,
-                pvpath=gserver,
-                options=options
+                storage_options=storage_options
             ))
-            return csi_pb2.NodePublishVolumeResponse()
+            # return csi_pb2.NodePublishVolumeResponse()
 
         # When 'storage_options' is configured mountpoint & volfile path change,
         # Update pvpath_full accordingly.

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -7,8 +7,7 @@ import time
 import csi_pb2
 import csi_pb2_grpc
 import grpc
-from volumeutils import (mount_glusterfs, mount_glusterfs_with_host,
-                         mount_volume, unmount_volume)
+from volumeutils import (mount_glusterfs, mount_volume, unmount_volume)
 
 from kadalulib import logf
 
@@ -81,20 +80,6 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
             storage_options=storage_options
         ))
 
-        if voltype == "External":
-            # If no separate PV Path, use the whole volume as PV
-            if pvpath == "":
-                mount_glusterfs_with_host(gvolname, request.target_path, gserver, options, True)
-
-                logging.debug(logf(
-                    "Mounted Volume for PV",
-                    volume=request.volume_id,
-                    mntdir=request.target_path,
-                    pvpath=gserver,
-                    options=options
-                ))
-                return csi_pb2.NodePublishVolumeResponse()
-
         volume = {
             'name': hostvol,
             'g_volname': gvolname,
@@ -104,6 +89,16 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
         }
 
         mountpoint = mount_glusterfs(volume, mntdir, storage_options, True)
+
+        if voltype == "External":
+            logging.debug(logf(
+                "Mounted Volume for PV",
+                volume=request.volume_id,
+                mntdir=mntdir,
+                pvpath=gserver,
+                options=options
+            ))
+            return csi_pb2.NodePublishVolumeResponse()
 
         # When 'storage_options' is configured mountpoint & volfile path change,
         # Update pvpath_full accordingly.

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1294,8 +1294,6 @@ def mount_glusterfs_with_host(volname, mountpoint, hosts, options=None, is_clien
         for option in options.split(","):
             g_ops.append(f"--{option}")
 
-    cmd.append(mountpoint)
-
     logging.debug(logf(
         "glusterfs command",
         cmd=cmd,

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -922,17 +922,17 @@ def generate_client_volfile(volname):
             data["disperse_redundancy"] = data["disperse"]["redundancy"]
 
         data["subvol_bricks_count"] = count
-        for i in range(0, int(len(data["bricks"]) / count)):
+        for i in range(0, int(len(data.get("bricks", [])) / count)):
             brick_name = "%s-%s-%d" % (
                 data["volname"],
                 "disperse" if data["type"] == "Disperse" else "replica",
                 i
             )
             data["dht_subvol"].append(brick_name)
-            if data["bricks"][(i * count)].get("decommissioned", "") != "":
+            if data.get("bricks", [])[(i * count)].get("decommissioned", "") != "":
                 decommissioned.append(brick_name)
 
-    data['decommissioned'] = "" if decommissioned == [] else ",".join(decommissioned)
+    data.get("decommissioned", "") = "" if decommissioned == [] else ",".join(decommissioned)
     template_file_path = os.path.join(
         TEMPLATES_DIR,
         "%s.client.vol.j2" % data["type"]

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1355,11 +1355,9 @@ def check_external_volume(pv_request, host_volumes):
         logging.warning("No host volume found to provide PV")
         return None
 
-    mount_glusterfs_with_host(hvol['g_volname'], mntdir, hvol['g_host'], hvol['g_options'])
+    mountpoint = mount_glusterfs(hvol, mntdir)
 
-    time.sleep(0.37)
-
-    if not is_gluster_mount_proc_running(hvol['g_volname'], mntdir):
+    if not mountpoint:
         logging.debug(logf(
             "Mount failed",
             hvol=hvol,

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -824,6 +824,10 @@ def volume_list(voltype=None):
 def mount_volume(pvpath, mountpoint, pvtype, fstype=None):
     """Mount a Volume"""
 
+    # Create subvol dir if PV is manually created
+    if not os.path.exists(pvpath):
+        makedirs(pvpath)
+
     # TODO: Will losetup survive container reboot?
     if pvtype == PV_TYPE_RAWBLOCK:
         # losetup of truncated file

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -932,7 +932,7 @@ def generate_client_volfile(volname):
             if data.get("bricks", [])[(i * count)].get("decommissioned", "") != "":
                 decommissioned.append(brick_name)
 
-    data.get("decommissioned", "") = "" if decommissioned == [] else ",".join(decommissioned)
+    data["decommissioned"] = "" if decommissioned == [] else ",".join(decommissioned)
     template_file_path = os.path.join(
         TEMPLATES_DIR,
         "%s.client.vol.j2" % data["type"]


### PR DESCRIPTION
1. Fixed non-existing "bricks" and "decommissioned" keys when using External glusterfs storage.

    Example of content for `data` with an external storage (`root@kadalu-csi-provisioner-0:/# cat /var/lib/gluster/data.info`: 
    ```json
    {"volname": "data", "volume_id": "f4b37c38-7517-11ec-b01e-f66bd7a0c157", "type": "External", "pvReclaimPolicy": "delete", "kadalu_format": "non-native", "gluster_hosts": "172.17.0.1", "gluster_volname": "data", "gluster_options": "log-level=DEBUG"}
    ```

2. Fixed duplicate mount path in the command line parameters