### PR TITLE
test: refactor and modify test code for readability

### DIFF
--- a/examples/sample-test-app1.yaml
+++ b/examples/sample-test-app1.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv1-1
+  labels:
+    type: replica1
 spec:
   storageClassName: kadalu.storage-pool-1
   accessModes:
@@ -17,6 +19,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv1-2
+  labels:
+    type: replica1
 spec:
   storageClassName: kadalu.storage-pool-1
   accessModes:
@@ -32,6 +36,7 @@ metadata:
   name: pod1-1
   labels:
     app: sample-app
+    type: replica1
 spec:
   containers:
   - name: sample-app
@@ -52,6 +57,7 @@ metadata:
   name: pod1-2
   labels:
     app: sample-app
+    type: replica1
 spec:
   containers:
   - name: sample-app
@@ -79,6 +85,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv1-3
+  labels:
+    type: replica1
 spec:
   storageClassName: kadalu.storage-pool-1-virtblock
   accessModes:
@@ -93,6 +101,7 @@ metadata:
   name: pod1-3
   labels:
     app: sample-app
+    type: replica1
 spec:
   containers:
   - name: sample-app
@@ -107,10 +116,12 @@ spec:
       claimName: pv1-3
   restartPolicy: OnFailure
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: pv1-4
+  labels:
+    type: replica1
 spec:
   accessModes:
     - ReadWriteOnce
@@ -124,6 +135,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod1-4
+  labels:
+    type: replica1
 spec:
   containers:
     - name: bash-block-vol

--- a/examples/sample-test-app2.yaml
+++ b/examples/sample-test-app2.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv2-1
+  labels:
+    type: replica2
 spec:
   storageClassName: kadalu.storage-pool-2
   accessModes:
@@ -19,6 +21,7 @@ metadata:
   name: pod2-1
   labels:
     app: sample-app
+    type: replica2
 spec:
   containers:
   - name: sample-app
@@ -38,6 +41,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv2-2
+  labels:
+    type: replica2
 spec:
   storageClassName: kadalu.storage-pool-2
   accessModes:
@@ -53,6 +58,7 @@ metadata:
   name: pod2-2
   labels:
     app: sample-app
+    type: replica2
 spec:
   containers:
   - name: sample-app
@@ -80,6 +86,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv2-3
+  labels:
+    type: replica2
 spec:
   storageClassName: kadalu.storage-pool-2-virtblock
   accessModes:
@@ -94,6 +102,7 @@ metadata:
   name: pod2-3
   labels:
     app: sample-app
+    type: replica2
 spec:
   containers:
   - name: sample-app
@@ -108,10 +117,12 @@ spec:
       claimName: pv2-3
   restartPolicy: OnFailure
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: pv2-4
+  labels:
+    type: replica2
 spec:
   accessModes:
     - ReadWriteOnce
@@ -125,6 +136,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod2-4
+  labels:
+    type: replica2
 spec:
   containers:
     - name: bash-block-vol

--- a/examples/sample-test-app2.yaml
+++ b/examples/sample-test-app2.yaml
@@ -152,3 +152,4 @@ spec:
     - name: csivol4
       persistentVolumeClaim:
         claimName: pv2-4
+  restartPolicy: OnFailure

--- a/examples/sample-test-app3.yaml
+++ b/examples/sample-test-app3.yaml
@@ -152,7 +152,7 @@ spec:
     - name: csivol4
       persistentVolumeClaim:
         claimName: pv3-4
-
+  restartPolicy: OnFailure
 # ---
 # kind: StorageClass
 # apiVersion: storage.k8s.io/v1

--- a/examples/sample-test-app3.yaml
+++ b/examples/sample-test-app3.yaml
@@ -153,88 +153,88 @@ spec:
       persistentVolumeClaim:
         claimName: pv3-4
 
----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: kadalu.storage-pool-3-storage-options
-provisioner: kadalu
-parameters:
-  storage_name: "storage-pool-3-with-9-pods"
-  storage_options:
-    "cluster/replicate.data-self-heal: off,\
-      performance/nl-cache.nl-cache: off"
+# ---
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: kadalu.storage-pool-3-storage-options
+# provisioner: kadalu
+# parameters:
+#   storage_name: "storage-pool-3-with-9-pods"
+#   storage_options:
+#     "cluster/replicate.data-self-heal: off,\
+#       performance/nl-cache.nl-cache: off"
 
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: pv3-5
-  labels:
-    type: replica3
-spec:
-  storageClassName: kadalu.storage-pool-3-storage-options
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 600Mi
+# ---
+# kind: PersistentVolumeClaim
+# apiVersion: v1
+# metadata:
+#   name: pv3-5
+#   labels:
+#     type: replica3
+# spec:
+#   storageClassName: kadalu.storage-pool-3-storage-options
+#   accessModes:
+#     - ReadWriteMany
+#   resources:
+#     requests:
+#       storage: 600Mi
 
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod3-5
-  labels:
-    app: sample-app
-    type: replica3
-spec:
-  containers:
-  - name: sample-app
-    image: docker.io/kadalu/sample-pv-check-app:latest
-    imagePullPolicy: IfNotPresent
-    volumeMounts:
-    - mountPath: "/mnt/pv"
-      name: csivol
-  volumes:
-  - name: csivol
-    persistentVolumeClaim:
-      claimName: pv3-5
-  restartPolicy: OnFailure
+# ---
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   name: pod3-5
+#   labels:
+#     app: sample-app
+#     type: replica3
+# spec:
+#   containers:
+#   - name: sample-app
+#     image: docker.io/kadalu/sample-pv-check-app:latest
+#     imagePullPolicy: IfNotPresent
+#     volumeMounts:
+#     - mountPath: "/mnt/pv"
+#       name: csivol
+#   volumes:
+#   - name: csivol
+#     persistentVolumeClaim:
+#       claimName: pv3-5
+#   restartPolicy: OnFailure
 
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: pv3-6
-  labels:
-    type: replica3
-spec:
-  storageClassName: kadalu.storage-pool-3-storage-options
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 800Mi
+# ---
+# kind: PersistentVolumeClaim
+# apiVersion: v1
+# metadata:
+#   name: pv3-6
+#   labels:
+#     type: replica3
+# spec:
+#   storageClassName: kadalu.storage-pool-3-storage-options
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 800Mi
 
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod3-6
-  labels:
-    app: sample-app
-    type: replica3
-spec:
-  containers:
-  - name: sample-app
-    image: docker.io/kadalu/sample-pv-check-app:latest
-    imagePullPolicy: IfNotPresent
-    volumeMounts:
-    - mountPath: "/mnt/pv"
-      name: csivol
-  volumes:
-  - name: csivol
-    persistentVolumeClaim:
-      claimName: pv3-6
-  restartPolicy: OnFailure
+# ---
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   name: pod3-6
+#   labels:
+#     app: sample-app
+#     type: replica3
+# spec:
+#   containers:
+#   - name: sample-app
+#     image: docker.io/kadalu/sample-pv-check-app:latest
+#     imagePullPolicy: IfNotPresent
+#     volumeMounts:
+#     - mountPath: "/mnt/pv"
+#       name: csivol
+#   volumes:
+#   - name: csivol
+#     persistentVolumeClaim:
+#       claimName: pv3-6
+#   restartPolicy: OnFailure

--- a/examples/sample-test-app3.yaml
+++ b/examples/sample-test-app3.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv3-1
+  labels:
+    type: replica3
 spec:
   storageClassName: kadalu.storage-pool-3
   accessModes:
@@ -19,6 +21,7 @@ metadata:
   name: pod3-1
   labels:
     app: sample-app
+    type: replica3
 spec:
   containers:
   - name: sample-app
@@ -38,6 +41,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv3-2
+  labels:
+    type: replica3
 spec:
   storageClassName: kadalu.storage-pool-3
   accessModes:
@@ -53,6 +58,7 @@ metadata:
   name: pod3-2
   labels:
     app: sample-app
+    type: replica3
 spec:
   containers:
   - name: sample-app
@@ -80,6 +86,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv3-3
+  labels:
+    type: replica3
 spec:
   storageClassName: kadalu.storage-pool-3-virtblock
   accessModes:
@@ -94,6 +102,7 @@ metadata:
   name: pod3-3
   labels:
     app: sample-app
+    type: replica3
 spec:
   containers:
   - name: sample-app
@@ -108,10 +117,12 @@ spec:
       claimName: pv3-3
   restartPolicy: OnFailure
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: pv3-4
+  labels:
+    type: replica3
 spec:
   accessModes:
     - ReadWriteOnce
@@ -125,6 +136,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod3-4
+  labels:
+    type: replica3
 spec:
   containers:
     - name: bash-block-vol
@@ -157,6 +170,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv3-5
+  labels:
+    type: replica3
 spec:
   storageClassName: kadalu.storage-pool-3-storage-options
   accessModes:
@@ -172,6 +187,7 @@ metadata:
   name: pod3-5
   labels:
     app: sample-app
+    type: replica3
 spec:
   containers:
   - name: sample-app
@@ -191,6 +207,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv3-6
+  labels:
+    type: replica3
 spec:
   storageClassName: kadalu.storage-pool-3-storage-options
   accessModes:
@@ -206,6 +224,7 @@ metadata:
   name: pod3-6
   labels:
     app: sample-app
+    type: replica3
 spec:
   containers:
   - name: sample-app

--- a/examples/sample-test-app4.yaml
+++ b/examples/sample-test-app4.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv4-1
+  labels:
+    type: disperse
 spec:
   storageClassName: kadalu.storage-pool-4
   accessModes:
@@ -19,6 +21,7 @@ metadata:
   name: pod4-1
   labels:
     app: sample-app
+    type: disperse
 spec:
   containers:
   - name: sample-app
@@ -38,6 +41,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv4-2
+  labels:
+    type: disperse
 spec:
   storageClassName: kadalu.storage-pool-4
   accessModes:
@@ -53,6 +58,7 @@ metadata:
   name: pod4-2
   labels:
     app: sample-app
+    type: disperse
 spec:
   containers:
   - name: sample-app
@@ -80,6 +86,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pv4-3
+  labels:
+    type: disperse
 spec:
   storageClassName: kadalu.storage-pool-4-virtblock
   accessModes:
@@ -94,6 +102,7 @@ metadata:
   name: pod4-3
   labels:
     app: sample-app
+    type: disperse
 spec:
   containers:
   - name: sample-app
@@ -108,10 +117,12 @@ spec:
       claimName: pv4-3
   restartPolicy: OnFailure
 ---
-apiVersion: v1
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
   name: pv4-4
+  labels:
+    type: disperse
 spec:
   accessModes:
     - ReadWriteOnce
@@ -125,6 +136,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod4-4
+  labels:
+    type: disperse
 spec:
   containers:
     - name: bash-block-vol

--- a/examples/sample-test-app4.yaml
+++ b/examples/sample-test-app4.yaml
@@ -152,3 +152,4 @@ spec:
     - name: csivol4
       persistentVolumeClaim:
         claimName: pv4-4
+  restartPolicy: OnFailure

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -1,160 +1,162 @@
 #!/bin/bash -e
 
-#Based on ideas from https://github.com/rook/rook/blob/master/tests/scripts/minikube.sh
+# Format via shfmt -> shfmt -i 2 -ci -w tests/minikube.sh
+
+# Based on ideas from https://github.com/rook/rook/blob/master/tests/scripts/minikube.sh
 fail=0
 
-ARCH=`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|'`
+ARCH=$(uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|')
 function wait_till_pods_start() {
-    # give it some time
+  # give it some time
 
-    cnt=0
-    local_timeout=${1:-200}
-    while true; do
-	cnt=$((cnt + 1))
-	sleep 2
-	ret=$(kubectl get pods -nkadalu -o wide | grep 'Running' | wc -l)
-	if [[ $ret -ge 21 ]]; then
-	    echo "Successful after $cnt seconds"
-	    break
-	fi
-	if [[ $cnt -eq ${local_timeout} ]]; then
-	    kubectl get pods -o wide
-	    echo "giving up after ${local_timeout} seconds"
-	    fail=1
-	    break
-	fi
-	if [[ $((cnt % 15)) -eq 0 ]]; then
-	    echo "$cnt: Waiting for pods to come up..."
-	fi
-    done
-
-    kubectl get sc
-    kubectl get pods -nkadalu -o wide
-    # Return failure if fail variable is set to 1
-    if [ $fail -eq 1 ]; then
-	echo "Marking the test as 'FAIL'"
-	for p in $(kubectl -n kadalu get pods -o name); do
-	    echo "====================== Start $p ======================"
-	    kubectl -nkadalu --all-containers=true --tail 300 logs $p
-	    kubectl -nkadalu describe $p
-	    echo "======================= End $p ======================="
-	done
-	exit 1
+  cnt=0
+  local_timeout=${1:-200}
+  while true; do
+    cnt=$((cnt + 1))
+    sleep 2
+    ret=$(kubectl get pods -nkadalu -o wide | grep 'Running' | wc -l)
+    if [[ $ret -ge 21 ]]; then
+      echo "Successful after $cnt seconds"
+      break
     fi
+    if [[ $cnt -eq ${local_timeout} ]]; then
+      kubectl get pods -o wide
+      echo "giving up after ${local_timeout} seconds"
+      fail=1
+      break
+    fi
+    if [[ $((cnt % 15)) -eq 0 ]]; then
+      echo "$cnt: Waiting for pods to come up..."
+    fi
+  done
+
+  kubectl get sc
+  kubectl get pods -nkadalu -o wide
+  # Return failure if fail variable is set to 1
+  if [ $fail -eq 1 ]; then
+    echo "Marking the test as 'FAIL'"
+    for p in $(kubectl -n kadalu get pods -o name); do
+      echo "====================== Start $p ======================"
+      kubectl -nkadalu --all-containers=true --tail 300 logs $p
+      kubectl -nkadalu describe $p
+      echo "======================= End $p ======================="
+    done
+    exit 1
+  fi
 }
 function get_pvc_and_check() {
-    yaml_file=$1
-    log_text=$2
-    pod_count=$3
-    time_limit=$4
+  yaml_file=$1
+  log_text=$2
+  pod_count=$3
+  time_limit=$4
 
-    echo "Running sample test app ${log_text} yaml from repo "
-    kubectl apply -f ${yaml_file}
+  echo "Running sample test app ${log_text} yaml from repo "
+  kubectl apply -f ${yaml_file}
 
-    cnt=0
-    result=0
-    while true; do
-	cnt=$((cnt + 1))
-	sleep 1
-	ret=$(kubectl get pods -o wide | grep 'Completed' | wc -l)
-	if [[ $ret -eq ${pod_count} ]]; then
-	    echo "Successful after $cnt seconds"
-	    break
-	fi
-	if [[ $cnt -eq ${time_limit} ]]; then
-	    kubectl get pvc
-	    kubectl get pods -nkadalu -o wide
-	    kubectl get pods -o wide
-	    echo "exiting after ${time_limit} seconds"
-	    result=1
-	    fail=1
-	    break
-	fi
-	if [[ $((cnt % 25)) -eq 0 ]]; then
-	    echo "$cnt: Waiting for pods to come up..."
-	fi
-    done
-    kubectl get pvc
-    kubectl get pods -o wide
+  cnt=0
+  result=0
+  while true; do
+    cnt=$((cnt + 1))
+    sleep 1
+    ret=$(kubectl get pods -o wide | grep 'Completed' | wc -l)
+    if [[ $ret -eq ${pod_count} ]]; then
+      echo "Successful after $cnt seconds"
+      break
+    fi
+    if [[ $cnt -eq ${time_limit} ]]; then
+      kubectl get pvc
+      kubectl get pods -nkadalu -o wide
+      kubectl get pods -o wide
+      echo "exiting after ${time_limit} seconds"
+      result=1
+      fail=1
+      break
+    fi
+    if [[ $((cnt % 25)) -eq 0 ]]; then
+      echo "$cnt: Waiting for pods to come up..."
+    fi
+  done
+  kubectl get pvc
+  kubectl get pods -o wide
 
-    #Delete the pods/pvc
-    for p in $(kubectl get pods -o name); do
-	[[ $result -eq 1 ]] && kubectl describe $p
-	[[ $result -eq 0 ]] && kubectl logs $p
-	[[ $p =~ -4 ]] && kubectl logs $p
-	kubectl delete $p
-    done
+  # Delete the pods/pvc
+  for p in $(kubectl get pods -o name); do
+    [[ $result -eq 1 ]] && kubectl describe $p
+    [[ $result -eq 0 ]] && kubectl logs $p
+    [[ $p =~ -4 ]] && kubectl logs $p
+    kubectl delete $p
+  done
 
-    for p in $(kubectl get pvc -o name); do
-	[[ $result -eq 1 ]] && kubectl describe $p
-	kubectl delete $p
-    done
+  for p in $(kubectl get pvc -o name); do
+    [[ $result -eq 1 ]] && kubectl describe $p
+    kubectl delete $p
+  done
 }
 
 function wait_for_ssh() {
-    local tries=100
-    while ((tries > 0)); do
-	if minikube ssh echo connected &>/dev/null; then
-	    return 0
-	fi
-	tries=$((tries - 1))
-	sleep 0.1
-    done
-    echo ERROR: ssh did not come up >&2
-    exit 1
+  local tries=100
+  while ((tries > 0)); do
+    if minikube ssh echo connected &>/dev/null; then
+      return 0
+    fi
+    tries=$((tries - 1))
+    sleep 0.1
+  done
+  echo ERROR: ssh did not come up >&2
+  exit 1
 }
 
 function copy_image_to_cluster() {
-    local build_image=$1
-    local final_image=$2
-    if [ -z "$(docker images -q "${build_image}")" ]; then
-	docker pull "${build_image}"
-    fi
-    if [[ "${VM_DRIVER}" == "none" ]]; then
-	docker tag "${build_image}" "${final_image}"
-	return
-    fi
-    docker save "${build_image}" | \
-	(eval "$(minikube docker-env --shell bash)" && \
-	     docker load && docker tag "${build_image}" "${final_image}")
+  local build_image=$1
+  local final_image=$2
+  if [ -z "$(docker images -q "${build_image}")" ]; then
+    docker pull "${build_image}"
+  fi
+  if [[ "${VM_DRIVER}" == "none" ]]; then
+    docker tag "${build_image}" "${final_image}"
+    return
+  fi
+  docker save "${build_image}" |
+    (eval "$(minikube docker-env --shell bash)" &&
+      docker load && docker tag "${build_image}" "${final_image}")
 }
 
 # install minikube
 function install_minikube() {
-    if type minikube >/dev/null 2>&1; then
-	local version
-	version=$(minikube version)
-	read -ra version <<<"${version}"
-	version=${version[2]}
-	if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
-	    echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
-	    #exit 1
-	fi
-	echo "minikube already installed with ${version}"
-	return 0
+  if type minikube >/dev/null 2>&1; then
+    local version
+    version=$(minikube version)
+    read -ra version <<<"${version}"
+    version=${version[2]}
+    if [[ "${version}" != "${MINIKUBE_VERSION}" ]]; then
+      echo "installed minikube version ${version} is not matching requested version ${MINIKUBE_VERSION}"
+      #exit 1
     fi
+    echo "minikube already installed with ${version}"
+    return 0
+  fi
 
-    echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
-    curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-${ARCH} && chmod +x minikube && mv minikube /usr/local/bin/
+  echo "Installing minikube. Version: ${MINIKUBE_VERSION}"
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/"${MINIKUBE_VERSION}"/minikube-linux-${ARCH} && chmod +x minikube && mv minikube /usr/local/bin/
 }
 
 function install_kubectl() {
-    if type kubectl >/dev/null 2>&1; then
-	local version
-	version=$(kubectl version --client | grep "${KUBE_VERSION}")
-	if [[ "x${version}" != "x" ]]; then
-	    echo "kubectl already installed with ${KUBE_VERSION}"
-	    return 0
-	fi
-	echo "installed kubectl version ${version} is not matching requested version ${KUBE_VERSION}"
-	#exit 1
+  if type kubectl >/dev/null 2>&1; then
+    local version
+    version=$(kubectl version --client | grep "${KUBE_VERSION}")
+    if [[ "x${version}" != "x" ]]; then
+      echo "kubectl already installed with ${KUBE_VERSION}"
+      return 0
     fi
-    # Download kubectl, which is a requirement for using minikube.
-    echo "Installing kubectl. Version: ${KUBE_VERSION}"
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBE_VERSION}"/bin/linux/${ARCH}/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
+    echo "installed kubectl version ${version} is not matching requested version ${KUBE_VERSION}"
+    # exit 1
+  fi
+  # Download kubectl, which is a requirement for using minikube.
+  echo "Installing kubectl. Version: ${KUBE_VERSION}"
+  curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBE_VERSION}"/bin/linux/${ARCH}/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
 }
 
-function run_io(){
+function run_io() {
 
   # Deploy io-app deployment with 2 replicas
   kubectl apply -f tests/test-io/io-app.yaml
@@ -162,7 +164,7 @@ function run_io(){
   # Compressed image is ~25MB and so it shouldn't take much time to reach ready state
   kubectl wait --for=condition=ready pod -l app=io-app --timeout=45s || fail=1
   if [ $fail == 1 ]; then
-      return 0
+    return 0
   fi
 
   # Store pod names
@@ -193,27 +195,27 @@ KUBE_VERSION=${KUBE_VERSION:-"v1.20.0"}
 COMMIT_MSG=${COMMIT_MSG:-""}
 MEMORY=${MEMORY:-"3000"}
 VM_DRIVER=${VM_DRIVER:-"none"}
-#configure image repo
+# configure image repo
 KADALU_IMAGE_REPO=${KADALU_IMAGE_REPO:-"docker.io/kadalu"}
 K8S_IMAGE_REPO=${K8S_IMAGE_REPO:-"quay.io/k8scsi"}
 
-#feature-gates for kube
+# feature-gates for kube
 K8S_FEATURE_GATES=${K8S_FEATURE_GATES:-"BlockVolume=true,CSIBlockVolume=true,VolumeSnapshotDataSource=true,CSIDriverRegistry=true"}
 
 DISK="sda1"
 if [[ "${VM_DRIVER}" == "kvm2" ]]; then
-    # use vda1 instead of sda1 when running with the libvirt driver
-    DISK="vda1"
+  # use vda1 instead of sda1 when running with the libvirt driver
+  DISK="vda1"
 fi
 
 case "${1:-}" in
-up)
+  up)
     echo "here"
     install_minikube || echo "failure"
-    #if driver  is 'none' install kubectl with KUBE_VERSION
+    # if driver  is 'none' install kubectl with KUBE_VERSION
     if [[ "${VM_DRIVER}" == "none" ]]; then
-	mkdir -p "$HOME"/.kube "$HOME"/.minikube
-	install_kubectl || echo "failure to install kubectl"
+      mkdir -p "$HOME"/.kube "$HOME"/.minikube
+      install_kubectl || echo "failure to install kubectl"
     fi
 
     echo "starting minikube with kubeadm bootstrapper"
@@ -221,70 +223,69 @@ up)
 
     # environment
     if [[ "${VM_DRIVER}" != "none" ]]; then
-	wait_for_ssh
-	# shellcheck disable=SC2086
-	minikube ssh "sudo mkdir -p /mnt/${DISK};sudo rm -rf /mnt/${DISK}/*; sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3,5.1,5.2,5.3,5.4,5.5,5.6,5.7,5.8,5.9}; sudo mkdir -p /mnt/${DISK}/{dir3.2,dir3.2_modified,pvc}"
+      wait_for_ssh
+      # shellcheck disable=SC2086
+      minikube ssh "sudo mkdir -p /mnt/${DISK};sudo rm -rf /mnt/${DISK}/*; sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3,5.1,5.2,5.3,5.4,5.5,5.6,5.7,5.8,5.9}; sudo mkdir -p /mnt/${DISK}/{dir3.2,dir3.2_modified,pvc}"
     else
-	sudo mkdir -p /mnt/${DISK}
-  sudo rm -rf /mnt/${DISK}/*
-	sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3,5.1,5.2,5.3,5.4,5.5,5.6,5.7,5.8,5.9}
-	sudo mkdir -p /mnt/${DISK}/dir3.2
-	sudo mkdir -p /mnt/${DISK}/dir3.2_modified
-	sudo mkdir -p /mnt/${DISK}/pvc
+      sudo mkdir -p /mnt/${DISK}
+      sudo rm -rf /mnt/${DISK}/*
+      sudo truncate -s 4g /mnt/${DISK}/file{1.1,1.2,1.3,2.1,2.2,3.1,4.1,4.2,4.3,5.1,5.2,5.3,5.4,5.5,5.6,5.7,5.8,5.9}
+      sudo mkdir -p /mnt/${DISK}/dir3.2
+      sudo mkdir -p /mnt/${DISK}/dir3.2_modified
+      sudo mkdir -p /mnt/${DISK}/pvc
     fi
 
     # Dump Cluster Info
     kubectl cluster-info
     ;;
-down)
+  down)
     minikube stop
     ;;
-copy-image)
+  copy-image)
     echo "copying the kadalu-operator image"
     copy_image_to_cluster kadalu/kadalu-operator:${KADALU_VERSION} "${KADALU_IMAGE_REPO}"/kadalu-operator:${KADALU_VERSION}
     ;;
-ssh)
+  ssh)
     echo "connecting to minikube"
     minikube ssh
     ;;
 
-kadalu_operator)
+  kadalu_operator)
     docker images
 
     if [[ ! "$COMMIT_MSG" =~ 'helm skip' ]]; then
 
-        # As per https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-        # `helm` is already part of github runner
-        for distro in kubernetes rke microk8s openshift
-        do
-            if [ "$distro" != "kubernetes" ]; then
-                export operator="kadalu-operator-$distro"
-                export nodeplugin="csi-nodeplugin-$distro"
-            else
-                export operator="kadalu-operator"
-                export nodeplugin="csi-nodeplugin"
-            fi
-            export verbose="yes" dist=$distro
-            echo Validating helm template for "'$distro'" against "'$operator'" [Empty for no diff]
-            echo
+      # As per https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      # `helm` is already part of github runner
+      for distro in kubernetes rke microk8s openshift; do
+        if [ "$distro" != "kubernetes" ]; then
+          export operator="kadalu-operator-$distro"
+          export nodeplugin="csi-nodeplugin-$distro"
+        else
+          export operator="kadalu-operator"
+          export nodeplugin="csi-nodeplugin"
+        fi
+        export verbose="yes" dist=$distro
+        echo Validating helm template for "'$distro'" against "'$operator'" [Empty for no diff]
+        echo
 
-            # Helm templates will not have 'kind: Namespace' so need to skip first 6 lines from operator manifest
-            if [ "$distro" == "openshift" ]; then
-                # Helm follows a specific order while installing/uninstalling (https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27)
-                # resources and it doesn't contain OpenShift 'SecurityContextConstraints' kind, so need to sort lines before 'diff'
-                diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#' | sort) \
-                    <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort ) --ignore-blank-lines
-            else
-                diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#') \
-                    <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' ) --ignore-blank-lines
-            fi
+        # Helm templates will not have 'kind: Namespace' so need to skip first 6 lines from operator manifest
+        if [ "$distro" == "openshift" ]; then
+          # Helm follows a specific order while installing/uninstalling (https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27)
+          # resources and it doesn't contain OpenShift 'SecurityContextConstraints' kind, so need to sort lines before 'diff'
+          diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#' | sort) \
+            <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
+        else
+          diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#') \
+            <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}') --ignore-blank-lines
+        fi
 
-            echo Validating helm template for "'$distro'" against "'$nodeplugin'" [Empty for no diff]
-            echo
-            diff <(helm template --namespace kadalu helm/kadalu --set csi-nodeplugin.enabled=true --set-string csi-nodeplugin.kubernetesDistro=$distro,csi-nodeplugin.verbose=$verbose | grep -v '#') \
-                <(grep -v '#' manifests/"$nodeplugin.yaml") --ignore-blank-lines
-        done
-        unset operator nodeplugin verbose dist
+        echo Validating helm template for "'$distro'" against "'$nodeplugin'" [Empty for no diff]
+        echo
+        diff <(helm template --namespace kadalu helm/kadalu --set csi-nodeplugin.enabled=true --set-string csi-nodeplugin.kubernetesDistro=$distro,csi-nodeplugin.verbose=$verbose | grep -v '#') \
+          <(grep -v '#' manifests/"$nodeplugin.yaml") --ignore-blank-lines
+      done
+      unset operator nodeplugin verbose dist
 
     fi
 
@@ -310,13 +311,13 @@ kadalu_operator)
     kubectl apply -f tests/get-minikube-pvc.yaml
 
     # Generally it needs some time for operator to get started, give it time, so some logs are reduced in tests
-    sleep 15;
+    sleep 15
     kubectl apply -f /tmp/kadalu-storage.yaml
 
     wait_till_pods_start
     ;;
 
-test_kadalu)
+  test_kadalu)
     date
 
     get_pvc_and_check examples/sample-test-app3.yaml "Replica3" 6 180
@@ -325,9 +326,9 @@ test_kadalu)
 
     get_pvc_and_check examples/sample-test-app4.yaml "Disperse" 4 120
 
-    #get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 60
+    # get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 60
 
-    #get_pvc_and_check examples/sample-external-kadalu-storage.yaml "External (Kadalu)" 2 90
+    # get_pvc_and_check examples/sample-external-kadalu-storage.yaml "External (Kadalu)" 2 90
 
     cp tests/storage-add.yaml /tmp/kadalu-storage.yaml
     sed -i -e "s/DISK/${DISK}/g" /tmp/kadalu-storage.yaml
@@ -335,13 +336,13 @@ test_kadalu)
     sed -i -e "s/dir3.2/dir3.2_modified/g" /tmp/kadalu-storage.yaml
     kubectl apply -f /tmp/kadalu-storage.yaml
 
-    sleep 5;
+    sleep 5
     echo "After modification"
     # Observing intermittent failures due to timeout after modification with a
     # difference of ~2 min
     wait_till_pods_start 400
 
-    #get_pvc_and_check examples/sample-test-app2.yaml "Replica2" 4 120
+    # get_pvc_and_check examples/sample-test-app2.yaml "Replica2" 4 120
 
     # Run minimal IO test
     run_io
@@ -363,7 +364,7 @@ test_kadalu)
     # Unless there is a failure or COMMIT_MSG contains 'full log' just log last 100 lines
     lines=100
     if [[ $fail -eq 1 || $COMMIT_MSG =~ 'full log' ]]; then
-        lines=1000
+      lines=1000
     fi
     for p in $(kubectl -n kadalu get pods -o name); do
       echo "====================== Start $p ======================"
@@ -375,9 +376,9 @@ test_kadalu)
     echo "List of storage-class"
     kubectl get sc -nkadalu
     for p in $(kubectl -n kadalu get pods -o name); do
-        if [[ $p == *"nodeplugin"* ]]; then
-            kubectl exec -i -nkadalu $p -c 'kadalu-nodeplugin' -- bash -c 'grep -e "data-self-heal off" -e "nl-cache off" /kadalu/volfiles/* | cat'
-        fi
+      if [[ $p == *"nodeplugin"* ]]; then
+        kubectl exec -i -nkadalu $p -c 'kadalu-nodeplugin' -- bash -c 'grep -e "data-self-heal off" -e "nl-cache off" /kadalu/volfiles/* | cat'
+      fi
     done
 
     date
@@ -391,15 +392,15 @@ test_kadalu)
 
     # Return failure if fail variable is set to 1
     if [ $fail -eq 1 ]; then
-	echo "Marking the test as 'FAIL'"
-	exit 1
+      echo "Marking the test as 'FAIL'"
+      exit 1
     else
-	echo "Tests SUCCESSFUL"
+      echo "Tests SUCCESSFUL"
     fi
 
     ;;
 
-cli_tests)
+  cli_tests)
     output=$(kubectl get nodes -o=name)
     # output will be in format 'node/hostname'. We need 'hostname'
     HOSTNAME=$(basename $output)
@@ -408,10 +409,10 @@ cli_tests)
     wait_till_pods_start
     ;;
 
-clean)
+  clean)
     minikube delete
     ;;
-*)
+  *)
     echo " $0 [command]
 Available Commands:
   up               Starts a local kubernetes cluster and prepare disks for gluster

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -83,7 +83,7 @@ function get_pvc_and_check() {
   local time_limit=$4
   local end_time=$(($(date +%s) + $time_limit))
 
-  local k="kubectl -nkadalu "
+  local k="kubectl "
 
   echo "Running sample test app ${log_text} yaml from repo "
   kubectl apply -f ${yaml_file}
@@ -92,9 +92,7 @@ function get_pvc_and_check() {
   local label="${log_text,,}"
 
   echo Waiting for sample pods creation with label $label
-  while [[ \
-    $($k get pod -l type=${label} -o name | wc -l) -eq 0 ]] \
-      ; do
+  while [[ $($k get pod -l type=${label} -o name | wc -l) -eq 0 ]]; do
     [[ $end_time -lt $(date +%s) ]] && echo Sample pods are not created with label $label && fail=1 && return
     sleep 2
   done

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -332,10 +332,13 @@ case "${1:-}" in
   test_kadalu)
     date
 
+    # type: Replica3
     get_pvc_and_check examples/sample-test-app3.yaml "Replica3" 6 180
 
+    # type: Replica1
     get_pvc_and_check examples/sample-test-app1.yaml "Replica1" 4 120
 
+    # type: Disperse
     get_pvc_and_check examples/sample-test-app4.yaml "Disperse" 4 120
 
     # get_pvc_and_check examples/sample-external-storage.yaml "External (PV)" 1 60
@@ -354,6 +357,7 @@ case "${1:-}" in
     # difference of ~2 min
     wait_till_pods_start 400
 
+    # type: Replica2
     # get_pvc_and_check examples/sample-test-app2.yaml "Replica2" 4 120
 
     # Run minimal IO test

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -445,7 +445,7 @@ case "${1:-}" in
     run_sanity
 
     # Test Storage-Options
-    verify_storage_options
+    # verify_storage_options
 
     # Display metrics output
     display_metrics

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -193,7 +193,7 @@ function run_io() {
   kubectl apply -f tests/test-io/io-app.yaml
 
   # Compressed image is ~25MB and so it shouldn't take much time to reach ready state
-  kubectl wait --for=condition=ready pod -l app=io-app --timeout=45s || fail=1
+  kubectl wait --for=condition=ready pod -l app=io-app --timeout=60s || fail=1
   if [ $fail == 1 ]; then
     return 0
   fi
@@ -217,7 +217,7 @@ function run_io() {
   echo Validate checksum between first and second pod [Empty for checksum match]
   diff <(echo "$first_sum") <(echo "$second_sum") || fail=1
 
-  return 0
+  check_test_fail
 }
 
 function run_sanity() {
@@ -236,6 +236,7 @@ function run_sanity() {
   [ $act_pass -ge $exp_pass ] || fail=1
   echo Sanity [Pass %]: Expected: $exp_pass and Actual: $act_pass
 
+  check_test_fail
 }
 
 function verify_storage_options() {

--- a/tests/storage-add.yaml
+++ b/tests/storage-add.yaml
@@ -87,29 +87,29 @@ spec:
 
 ## -------------------------------------------------------------------
 # This storage is used for testing storage-options with 9 storage-pods
----
-apiVersion: kadalu-operator.storage/v1alpha1
-kind: KadaluStorage
-metadata:
-  name: storage-pool-3-with-9-pods
-spec:
-  type: Replica3
-  storage:
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.1 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.2 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.3 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.4 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.5 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.6 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.7 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.8 # file as a device
-    - node: minikube            # node name as shown in `kubectl get nodes`
-      device: /mnt/DISK/file5.9 # file as a device
+# ---
+# apiVersion: kadalu-operator.storage/v1alpha1
+# kind: KadaluStorage
+# metadata:
+#   name: storage-pool-3-with-9-pods
+# spec:
+#   type: Replica3
+#   storage:
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.1 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.2 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.3 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.4 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.5 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.6 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.7 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.8 # file as a device
+#     - node: minikube            # node name as shown in `kubectl get nodes`
+#       device: /mnt/DISK/file5.9 # file as a device


### PR DESCRIPTION
- run `shfmt` on bash test file
- fail the test when first failure is occurred
- add labels to pvc and pods deployed during test
- prefer using kubectl wait rather than bash polling
- move test units into individual functions
- do not test storage options temporarily
- make sure `restartPolicy: OnFailure` exists on all test app pods

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>