### PR TITLE
Updated Read me to contains commands to allow kadalu to run on OCP. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ curl -s https://raw.githubusercontent.com/kadalu/kadalu/devel/extras/scripts/cle
 ```
 
 
+### OpenShift
+If you are are running Kadalu on OpenShift (OCP)  the following commands must be run to give priviledged roles to the service accounts. 
+```
+oc adm policy add-scc-to-user privileged -z kadalu-operator  -n kadalu
+oc adm policy add-scc-to-user privileged -z kadalu-csi-nodeplugin -n kadalu
+oc adm policy add-scc-to-user privileged -z kadalu-server-sa -n kadalu
+oc adm policy add-scc-to-user privileged -z kadalu-csi-provisioner -n kadalu
+```
+
+
+
+
+
 ## Reach out
 
 1. Best is opening an [issue in github.](https://github.com/kadalu/kadalu/issues)


### PR DESCRIPTION
This was tested on OCP 4.8

Signed-off-by: Chris Phillips <chris.phillips@uk.ibm.com>