### PR TITLE
Change the operator/exporter timeout to 10s

### DIFF
--- a/kadalu_operator/exporter.py
+++ b/kadalu_operator/exporter.py
@@ -271,7 +271,7 @@ def collect_all_metrics():
         try:
             response = requests.get(
                 'http://'+ pod_details["ip_address"] +':8050/_api/metrics',
-                timeout=1)
+                timeout=10)
 
             if response.status_code == 200:
                 if "nodeplugin" in pod_name:


### PR DESCRIPTION
In some cases 1s is not enough to collect the kadalu metrics ,so I'm proposing a 10s timeout. '5s' was succeeding 2/3 times , so maybe a smaller one would be better.

I was thinking if it can run the requests in parallel , but the resources for the operator are limited.

@aravindavk , @amarts ,
do you think that such large timeout can cause issues, for example if the for loop is delayed for 50s (5 endpoints * 10s each) ?