### PR TITLE
Change operator/exporter's timeout to 10s

### DIFF
--- a/kadalu_operator/exporter.py
+++ b/kadalu_operator/exporter.py
@@ -291,7 +291,7 @@ def collect_all_metrics():
         try:
             response = requests.get(
                 'http://'+ pod_details["ip_address"] +':8050/_api/metrics',
-                timeout=1)
+                timeout=10)
 
             if response.status_code == 200:
                 if "nodeplugin" in pod_name:


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the exported can't connect to the endpoints for one second (busy environemnts),so a bigger timeout is needed.

**Special notes for your reviewer**:
As we don't use parallel metrics retrieving , if multiple endpoints do not response - the total time for the for-loop can grow significantly. @aravindavk , @amarts , do you think that there could be issues if the whole for-loop takes more time (like 5 endpoints * 10s timeout = 50s total time to execute the for-loop) ?