### PR TITLE
cli: Fecth pv_stats from provisioner pod

### DIFF
--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -187,15 +187,16 @@ def fetch_status(storages, args):
         if args.name is not None and args.name != storage.storage_name:
             continue
 
-        dbpath = "/bricks/" + storage.storage_name + "/data/brick/stat.db"
+        dbpath = "/mnt/" + storage.storage_name + "/stat.db"
         query = ("select size from summary;"
                  "select count(pvname), sum(size), min(size), "
                  "avg(size), max(size) from pv_stats")
 
         cmd = utils.kubectl_cmd(args) + [
-            "exec", "-it",
-            storage.storage_units[0].podname,
-            "-nkadalu", "--", "sqlite3",
+            "exec", "-it", "-nkadalu",
+            "kadalu-csi-provisioner-0",
+            "-c", "kadalu-provisioner",
+            "--", "sqlite3",
             dbpath,
             query
         ]


### PR DESCRIPTION
Fixes: #801
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>

**What this PR does / why we need it**:
This PR gets stats on storage-list subcommand by exec into provisioner pod rather than server-pods.