### PR TITLE
Add openshift monitoring label, fixes kadalu#808

### DIFF
--- a/templates/operator.yaml.j2
+++ b/templates/operator.yaml.j2
@@ -16,6 +16,11 @@ apiVersion: v1
 metadata:
   name: kadalu-csi-nodeplugin
   namespace: {{ namespace }}
+  {% if k8s_dist == "openshift" %}
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  {% endif %}
+ 
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -285,7 +285,7 @@ function validate_helm() {
           <(grep -v '#' manifests/"$operator.yaml" | tail -n +8 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
       else
         diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#') \
-          <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}') --ignore-blank-lines
+          <(grep -v '#' manifests/"$operator.yaml" | tail -n +8 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}') --ignore-blank-lines
       fi
 
       echo Validating helm template for "'$distro'" against "'$nodeplugin'" [Empty for no diff]

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -277,6 +277,7 @@ function validate_helm() {
       echo Validating helm template for "'$distro'" against "'$operator'" [Empty for no diff]
       echo
 
+set -x
       # Helm templates will not have 'kind: Namespace' so need to skip first 6 lines from operator manifest
       if [ "$distro" == "openshift" ]; then
         # Helm follows a specific order while installing/uninstalling (https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27)
@@ -294,7 +295,7 @@ function validate_helm() {
         <(grep -v '#' manifests/"$nodeplugin.yaml") --ignore-blank-lines
     done
     unset operator nodeplugin verbose dist
-
+set +x
   fi
 }
 

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -282,7 +282,7 @@ function validate_helm() {
         # Helm follows a specific order while installing/uninstalling (https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27)
         # resources and it doesn't contain OpenShift 'SecurityContextConstraints' kind, so need to sort lines before 'diff'
         diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#' | sort) \
-          <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
+          <(grep -v '#' manifests/"$operator.yaml" | tail -n +8 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
       else
         diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#') \
           <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}') --ignore-blank-lines

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -277,13 +277,13 @@ function validate_helm() {
       echo Validating helm template for "'$distro'" against "'$operator'" [Empty for no diff]
       echo
 
-set -x
+
       # Helm templates will not have 'kind: Namespace' so need to skip first 6 lines from operator manifest
       if [ "$distro" == "openshift" ]; then
         # Helm follows a specific order while installing/uninstalling (https://github.com/helm/helm/blob/release-3.0/pkg/releaseutil/kind_sorter.go#L27)
         # resources and it doesn't contain OpenShift 'SecurityContextConstraints' kind, so need to sort lines before 'diff'
         diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#' | sort) \
-          <(grep -v '#' manifests/"$operator.yaml" | tail -n +8 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
+          <(grep -v '#' manifests/"$operator.yaml" | tail -n +6 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}' | sort) --ignore-blank-lines
       else
         diff <(helm template --namespace kadalu helm/kadalu --set operator.enabled=true --set-string operator.kubernetesDistro=$distro,operator.verbose=$verbose | grep -v '#') \
           <(grep -v '#' manifests/"$operator.yaml" | tail -n +8 | sed '/^kind: CustomResourceDefinition/,/^spec:/{/namespace/d}') --ignore-blank-lines
@@ -295,7 +295,7 @@ set -x
         <(grep -v '#' manifests/"$nodeplugin.yaml") --ignore-blank-lines
     done
     unset operator nodeplugin verbose dist
-set +x
+
   fi
 }
 


### PR DESCRIPTION
Signed-off-by: hunter86bg <hunter86_bg@yahoo.com>


**What this PR does / why we need it**:
When gen_manifest.py is triggered, the resulting manifests/kadalu-operator-openshift.yaml is created  has no label for Prometheus monitoring which leads to Prometheus ignore Kadalu Metrics

**Special notes for your reviewer**:
This commit should lead to an updated "kadalu-operator-openshift.yaml" that will have the label which will prevent users that update

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
