### PR TITLE
multiple fixes in CSI RPC methods wrt voltypes

### DIFF
--- a/csi/quota-crawler.sh
+++ b/csi/quota-crawler.sh
@@ -6,7 +6,7 @@ echo "Starting the quota crawler script"
 count=0
 while true; do
 
-  dirs=$(/bin/ls -d $MOUNT_DIR/*/subvol 2>/dev/null| wc -l);
+  dirs=$(find $MOUNT_DIR/*/subvol -type d -mindepth 1 -maxdepth 1 -printf '.' 2>/dev/null| wc -l);
   if [ $dirs -lt 1 ] ; then
     if [ $((count % 100)) -eq 0 ]; then
       echo "No PVC yet, continuing to watch..."

--- a/examples/sample-test-app1.yaml
+++ b/examples/sample-test-app1.yaml
@@ -12,7 +12,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 300Mi
+      storage: 200Mi
 # -*- mode: yaml -*-
 ---
 kind: PersistentVolumeClaim
@@ -27,7 +27,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 # -*- mode: yaml -*-
 ---
 apiVersion: v1
@@ -77,6 +77,7 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.storage-pool-1-virtblock
 provisioner: kadalu
+allowVolumeExpansion: true
 parameters:
   storage_name: "storage-pool-1"
   pv_type: Block
@@ -93,7 +94,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod
@@ -129,7 +130,7 @@ spec:
   storageClassName: kadalu.storage-pool-1
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod

--- a/examples/sample-test-app2.yaml
+++ b/examples/sample-test-app2.yaml
@@ -12,7 +12,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 50Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -49,7 +49,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -77,6 +77,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.storage-pool-2-virtblock
+allowVolumeExpansion: true
 provisioner: kadalu
 parameters:
   storage_name: "storage-pool-2"
@@ -94,7 +95,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod
@@ -130,7 +131,7 @@ spec:
   storageClassName: kadalu.storage-pool-2
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod

--- a/examples/sample-test-app3.yaml
+++ b/examples/sample-test-app3.yaml
@@ -12,7 +12,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 600Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -49,7 +49,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 800Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -77,6 +77,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.storage-pool-3-virtblock
+allowVolumeExpansion: true
 provisioner: kadalu
 parameters:
   storage_name: "storage-pool-3"
@@ -94,7 +95,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod
@@ -130,7 +131,7 @@ spec:
   storageClassName: kadalu.storage-pool-3
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod
@@ -178,7 +179,7 @@ spec:
 #     - ReadWriteMany
 #   resources:
 #     requests:
-#       storage: 600Mi
+#       storage: 200Mi
 
 # ---
 # apiVersion: v1
@@ -215,7 +216,7 @@ spec:
 #     - ReadWriteOnce
 #   resources:
 #     requests:
-#       storage: 800Mi
+#       storage: 200Mi
 
 # ---
 # apiVersion: v1

--- a/examples/sample-test-app4.yaml
+++ b/examples/sample-test-app4.yaml
@@ -12,7 +12,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 600Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -49,7 +49,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 800Mi
+      storage: 200Mi
 
 ---
 apiVersion: v1
@@ -77,6 +77,7 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: kadalu.storage-pool-4-virtblock
+allowVolumeExpansion: true
 provisioner: kadalu
 parameters:
   storage_name: "storage-pool-4"
@@ -94,7 +95,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod
@@ -130,7 +131,7 @@ spec:
   storageClassName: kadalu.storage-pool-4
   resources:
     requests:
-      storage: 500Mi
+      storage: 200Mi
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
controllerserver:
- while expanding the volume infer the voltype from stored pvc metadata
  from backend
- there's a possibility only checking for accessbility may not
  differentiate b/n subvol and virtblock
- expansion of virtblock is similar to rawblock expect the fs expansion
  and show the same in code
- expand on PVC path of virtblock not on mountdir

quota-crawler:
- use find rather than ls to start quota update of subvol dirs

volumeutils:
- use os.truncate rather than raw truncate to workaround subproccess's
  'TypeError: expected str, bytes or os.PathLike object, not int'
- do not run mkfs.xfs while expanding virtblock volume
- delete a pvc and info metadata from leaf dir upto non empty dir
  excluding voltype dirs (subvol/virtblock/rawblock)
- removing the empty leaf nodes should speed up metrics collection if
  there are multiple PVC CRUD operations happening in the cluster
- include rawblock volumes in search operations

tests:
- set all the PVC original size to 200Mi and expand to 300Mi in the test
- set allowVolumeExpansion to true for custom created virtblock storage
  classes
- fix test for app pods success state
- add tests for expansion and verification of no leaf nodes when all
  PVCs are removed

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>