### PR TITLE
Allow building images directly from repository

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -40,18 +40,14 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Copy all requirements files to root of the repo for building images
-        run: |
-          cp -r requirements/* .
-
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('ci_merge-requirements.txt') }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/ci_merge-requirements.txt') }}
 
       - name: Get the CLI build (kubectl-kadalu)
         run: |
-          python -m pip install --upgrade --upgrade-strategy eager -r ci_merge-requirements.txt -e .
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_merge-requirements.txt -e .
           KADALU_VERSION=devel make cli-build
 
       - name: Builder Image

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get the CLI build (kubectl-kadalu)
         run: |
-          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_merge-requirements.txt -e .
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_merge-requirements.txt -e ./requirements
           KADALU_VERSION=devel make cli-build
 
       - name: Builder Image

--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Install dependencies pylint
       run: |
-          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_submit-requirements.txt -r requirements/ci_merge-requirements.txt -e .
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_submit-requirements.txt -r requirements/ci_merge-requirements.txt -e ./requirements
 
     - name: Run pylint
       run: make pylint

--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -43,18 +43,14 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Copy all requirements files to root of the repo
-      run: |
-        cp -r requirements/* .
-
     - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('ci_submit-requirements.txt') }}-${{ hashFiles('ci_merge-requirements.txt') }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements/ci_submit-requirements.txt') }}-${{ hashFiles('requirements/ci_merge-requirements.txt') }}
 
     - name: Install dependencies pylint
       run: |
-          python -m pip install --upgrade --upgrade-strategy eager -r ci_submit-requirements.txt -r ci_merge-requirements.txt -e .
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_submit-requirements.txt -r requirements/ci_merge-requirements.txt -e .
 
     - name: Run pylint
       run: make pylint

--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -113,9 +113,6 @@ jobs:
         run: |
           python -m pip install -r requirements/ci_merge-requirements.txt
           KADALU_VERSION=${{ env.kadalu_version }} make cli-build
-      - name: Copy all requirements files to root of the repo for building images
-        run: |
-          cp -r requirements/* .
       -
         name: Build Builder Image
         uses: docker/build-push-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use helm for generating devel manifests
 - Harden RBAC permissions
 - Support custom kubelet dir
+- Container images can now be built directly from the repository without dependencies on previous build steps
 
 ## [0.8.15] - 2022-06-16
 

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,6 @@
 
 set -e -o pipefail
 
-cp -f requirements/*-requirements.txt .
-trap "rm -f *-requirements.txt" EXIT
-
 DOCKER_USER="${DOCKER_USER:-kadalu}"
 KADALU_VERSION="${KADALU_VERSION}"
 

--- a/cli/build/kubectl-kadalu
+++ b/cli/build/kubectl-kadalu
@@ -1,0 +1,2 @@
+# This file exists as a hack to allow direct image building without requiring extra build steps
+# See https://github.com/kadalu/kadalu/issues/839

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -4,7 +4,7 @@ FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
-COPY csi-requirements.txt /tmp/
+COPY requirements/csi-requirements.txt /tmp/
 
 RUN python3 -m pip install -r /tmp/csi-requirements.txt --no-cache-dir && \
     grep -Po '^[\w\.-]*(?=)' /tmp/csi-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -17,7 +17,7 @@ RUN apt-get update -yq && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|' | sed 's|armv7l|arm|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 
-COPY builder-requirements.txt /tmp/
+COPY requirements/builder-requirements.txt /tmp/
 RUN python3 -m venv $VIRTUAL_ENV && cd $VIRTUAL_ENV && sleep 1 && which python3 && which pip && \
     $VIRTUAL_ENV/bin/pip install -r /tmp/builder-requirements.txt --no-cache-dir && \
     grep -Po '^[\w\.-]*(?=)' /tmp/builder-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'

--- a/kadalu_operator/Dockerfile
+++ b/kadalu_operator/Dockerfile
@@ -4,7 +4,7 @@ FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
-COPY operator-requirements.txt /tmp/
+COPY requirements/operator-requirements.txt /tmp/
 
 RUN python3 -m pip install -r /tmp/operator-requirements.txt --no-cache-dir && \
     grep -Po '^[\w\.-]*(?=)' /tmp/operator-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,7 @@ FROM kadalu/builder:${builder_version} as builder
 
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 
-COPY server-requirements.txt /tmp/
+COPY requirements/server-requirements.txt /tmp/
 
 RUN python3 -m pip install -r /tmp/server-requirements.txt --no-cache-dir && \
     grep -Po '^[\w\.-]*(?=)' /tmp/server-requirements.txt | xargs -I pkg python3 -m pip show pkg | grep -P '^(Name|Version|Location)'


### PR DESCRIPTION
This removes a redundant copying of "requirements.txt"s
during the container image build process
and instead directly references the requirements files
in the `/requirements` directory.

This change enables usage of build tools which directly
build images from clong a git repository (like kaniko).

<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
Removes redundant copying of `requirement.txt` files and removes dependency on `build.sh` for building Containerfiles from the repository.

**Which issue(s) this PR fixes**:
Fixes #839 

**Special notes for your reviewer**:
Please let me know if I missed a hidden purpose for why this copying takes place.

**Checklist**
- [ ] -Documentation added- Not required AFAIK
- [x] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.
