### PR TITLE
Remove CSI Attacher sidecar and corresponding RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Use helm for generating devel manifests
+- Fix idempotency while creating block volumes
 - Harden RBAC permissions
 - Support custom kubelet dir
+- Use recommended path for kernel shared modules in server pod
+- Remove CSI Attacher Sidecar and corresponding RBAC
+- Update CSI Sidecar Images except node-driver-registrar
 
 ## [0.8.15] - 2022-06-16
 

--- a/doc/using-with-private-container-registry.adoc
+++ b/doc/using-with-private-container-registry.adoc
@@ -18,9 +18,8 @@ sudo docker pull docker.io/kadalu/kadalu-operator:devel
 sudo docker pull docker.io/kadalu/kadalu-server:devel
 sudo docker pull docker.io/raspbernetes/csi-node-driver-registrar:2.0.1
 sudo docker pull docker.io/library/busybox
-sudo docker pull docker.io/raspbernetes/csi-external-provisioner:2.0.2
-sudo docker pull docker.io/raspbernetes/csi-external-attacher:3.0.0
-sudo docker pull docker.io/raspbernetes/csi-external-resizer:1.0.0
+sudo docker pull docker.io/raspbernetes/csi-external-provisioner:2.2.1
+sudo docker pull docker.io/raspbernetes/csi-external-resizer:1.2.0
 ----
 
 **Note:** Change the version of Kadalu Container images as required.
@@ -33,9 +32,8 @@ sudo docker tag docker.io/kadalu/kadalu-operator:devel my_company_images:5000/ka
 sudo docker tag docker.io/kadalu/kadalu-server:devel my_company_images:5000/kadalu/kadalu-server:devel
 sudo docker tag docker.io/raspbernetes/csi-node-driver-registrar:2.0.1 my_company_images:5000/raspbernetes/csi-node-driver-registrar:2.0.1
 sudo docker tag docker.io/library/busybox my_company_images:5000/library/busybox
-sudo docker tag docker.io/raspbernetes/csi-external-provisioner:2.0.2 my_company_images:5000/raspbernetes/csi-external-provisioner:2.0.2
-sudo docker tag docker.io/raspbernetes/csi-external-attacher:3.0.0 my_company_images:5000/raspbernetes/csi-external-attacher:3.0.0
-sudo docker tag docker.io/raspbernetes/csi-external-resizer:1.0.0 my_company_images:5000/raspbernetes/csi-external-resizer:1.0.0
+sudo docker tag docker.io/raspbernetes/csi-external-provisioner:2.2.1 my_company_images:5000/raspbernetes/csi-external-provisioner:2.2.1
+sudo docker tag docker.io/raspbernetes/csi-external-resizer:1.2.0 my_company_images:5000/raspbernetes/csi-external-resizer:1.2.0
 ----
 
 Upload the images to private repository.
@@ -46,9 +44,8 @@ sudo docker push my_company_images:5000/kadalu/kadalu-operator:devel
 sudo docker push my_company_images:5000/kadalu/kadalu-server:devel
 sudo docker push my_company_images:5000/raspbernetes/csi-node-driver-registrar:2.0.1
 sudo docker push my_company_images:5000/library/busybox
-sudo docker push my_company_images:5000/raspbernetes/csi-external-provisioner:2.0.2
-sudo docker push my_company_images:5000/raspbernetes/csi-external-attacher:3.0.0
-sudo docker push my_company_images:5000/raspbernetes/csi-external-resizer:1.0.0
+sudo docker push my_company_images:5000/raspbernetes/csi-external-provisioner:2.2.1
+sudo docker push my_company_images:5000/raspbernetes/csi-external-resizer:1.2.0
 ----
 
 == Generate Manifest files

--- a/helm/kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
+++ b/helm/kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: {{ .Release.Namespace }}

--- a/helm/kadalu/charts/operator/templates/rbac.yaml
+++ b/helm/kadalu/charts/operator/templates/rbac.yaml
@@ -23,26 +23,6 @@ rules:
     verbs:
       - watch
 ---
-# CSI External Attacher
-# https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
----
 # CSI External Provisioner
 # https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
 kind: ClusterRole
@@ -73,10 +53,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  # PUBLISH_UNPUBLISH_VOLUME capability
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
 ---
 # CSI External Resizer
@@ -113,19 +89,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kadalu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-subjects:
-  - kind: ServiceAccount
-    name: kadalu-csi-provisioner
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: kadalu-csi-external-attacher
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRoleBinding

--- a/helm/kadalu/charts/operator/templates/serviceaccount.yaml
+++ b/helm/kadalu/charts/operator/templates/serviceaccount.yaml
@@ -8,12 +8,6 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: kadalu-csi-nodeplugin
-  namespace: {{ .Release.Namespace }}
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
   name: kadalu-csi-provisioner
   namespace: {{ .Release.Namespace }}
 ---

--- a/manifests/csi-nodeplugin-microk8s.yaml
+++ b/manifests/csi-nodeplugin-microk8s.yaml
@@ -5,6 +5,13 @@ apiVersion: v1
 metadata:
   name: kadalu
 ---
+# Source: kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: kadalu
+---
 # Source: kadalu/charts/csi-nodeplugin/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/csi-nodeplugin-openshift.yaml
+++ b/manifests/csi-nodeplugin-openshift.yaml
@@ -5,6 +5,13 @@ apiVersion: v1
 metadata:
   name: kadalu
 ---
+# Source: kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: kadalu
+---
 # Source: kadalu/charts/csi-nodeplugin/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/csi-nodeplugin-rke.yaml
+++ b/manifests/csi-nodeplugin-rke.yaml
@@ -5,6 +5,13 @@ apiVersion: v1
 metadata:
   name: kadalu
 ---
+# Source: kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: kadalu
+---
 # Source: kadalu/charts/csi-nodeplugin/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/csi-nodeplugin.yaml
+++ b/manifests/csi-nodeplugin.yaml
@@ -5,6 +5,13 @@ apiVersion: v1
 metadata:
   name: kadalu
 ---
+# Source: kadalu/charts/csi-nodeplugin/templates/serviceaccount.yaml
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kadalu-csi-nodeplugin
+  namespace: kadalu
+---
 # Source: kadalu/charts/csi-nodeplugin/templates/clusterrole.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -16,13 +16,6 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: kadalu-csi-nodeplugin
-  namespace: kadalu
----
-# Source: kadalu/charts/operator/templates/serviceaccount.yaml
-kind: ServiceAccount
-apiVersion: v1
-metadata:
   name: kadalu-csi-provisioner
   namespace: kadalu
 ---
@@ -161,27 +154,6 @@ rules:
       - watch
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
-# CSI External Attacher
-# https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Provisioner
 # https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
 kind: ClusterRole
@@ -212,10 +184,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  # PUBLISH_UNPUBLISH_VOLUME capability
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
@@ -254,20 +222,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kadalu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-subjects:
-  - kind: ServiceAccount
-    name: kadalu-csi-provisioner
-    namespace: kadalu
-roleRef:
-  kind: ClusterRole
-  name: kadalu-csi-external-attacher
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -18,13 +18,6 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: kadalu-csi-nodeplugin
-  namespace: kadalu
----
-# Source: kadalu/charts/operator/templates/serviceaccount.yaml
-kind: ServiceAccount
-apiVersion: v1
-metadata:
   name: kadalu-csi-provisioner
   namespace: kadalu
 ---
@@ -163,27 +156,6 @@ rules:
       - watch
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
-# CSI External Attacher
-# https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Provisioner
 # https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
 kind: ClusterRole
@@ -214,10 +186,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  # PUBLISH_UNPUBLISH_VOLUME capability
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
@@ -256,20 +224,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kadalu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-subjects:
-  - kind: ServiceAccount
-    name: kadalu-csi-provisioner
-    namespace: kadalu
-roleRef:
-  kind: ClusterRole
-  name: kadalu-csi-external-attacher
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -16,13 +16,6 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: kadalu-csi-nodeplugin
-  namespace: kadalu
----
-# Source: kadalu/charts/operator/templates/serviceaccount.yaml
-kind: ServiceAccount
-apiVersion: v1
-metadata:
   name: kadalu-csi-provisioner
   namespace: kadalu
 ---
@@ -161,27 +154,6 @@ rules:
       - watch
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
-# CSI External Attacher
-# https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Provisioner
 # https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
 kind: ClusterRole
@@ -212,10 +184,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  # PUBLISH_UNPUBLISH_VOLUME capability
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
@@ -254,20 +222,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kadalu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-subjects:
-  - kind: ServiceAccount
-    name: kadalu-csi-provisioner
-    namespace: kadalu
-roleRef:
-  kind: ClusterRole
-  name: kadalu-csi-external-attacher
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -16,13 +16,6 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: kadalu-csi-nodeplugin
-  namespace: kadalu
----
-# Source: kadalu/charts/operator/templates/serviceaccount.yaml
-kind: ServiceAccount
-apiVersion: v1
-metadata:
   name: kadalu-csi-provisioner
   namespace: kadalu
 ---
@@ -161,27 +154,6 @@ rules:
       - watch
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
-# CSI External Attacher
-# https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments/status"]
-    verbs: ["patch"]
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Provisioner
 # https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml
 kind: ClusterRole
@@ -212,10 +184,6 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  # PUBLISH_UNPUBLISH_VOLUME capability
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
@@ -254,20 +222,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: kadalu-operator
-  apiGroup: rbac.authorization.k8s.io
----
-# Source: kadalu/charts/operator/templates/rbac.yaml
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kadalu-csi-external-attacher
-subjects:
-  - kind: ServiceAccount
-    name: kadalu-csi-provisioner
-    namespace: kadalu
-roleRef:
-  kind: ClusterRole
-  name: kadalu-csi-external-attacher
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kadalu-csi-provisioner
       containers:
         - name: csi-provisioner
-          image: {{ images_hub }}/raspbernetes/csi-external-provisioner:2.0.2
+          image: {{ images_hub }}/raspbernetes/csi-external-provisioner:2.2.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -43,21 +43,6 @@ spec:
               value: "{{ k8s_dist }}"
             - name: VERBOSE
               value: "{{ verbose }}"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-attacher
-          image: {{ images_hub }}/raspbernetes/csi-external-attacher:3.0.0
-          args:
-            - "--v=5"
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: KADALU_VERSION
-              value: "{{ kadalu_version }}"
-            - name: K8S_DIST
-              value: "{{ k8s_dist }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -109,7 +94,7 @@ spec:
             - name: varlog
               mountPath: "/var/log/gluster"
         - name: csi-resizer
-          image: {{ images_hub }}/raspbernetes/csi-external-resizer:1.0.0
+          image: {{ images_hub }}/raspbernetes/csi-external-resizer:1.2.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"


### PR DESCRIPTION
Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>

**What this PR does / why we need it**:
- Update CSI Sidecar images for provisioner not requiring to watch
  volumeattachments

**Which issue(s) this PR fixes**:
Fixes #861 
Ref #848 

**Special notes for your reviewer**:

**Checklist**
- [X] Documentation added
- [ ] Tests updated
- [X] Add an entry in the `CHANGELOG.md` about the changes.
