### PR TITLE
Allow tolerations to be set on server pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden RBAC permissions
 - Support custom kubelet dir
 - Container images can now be built directly from the repository without dependencies on previous build steps
+- Enable and correctly handle tolerations supplied in KadaluStorage CR
 
 ## [0.8.15] - 2022-06-16
 

--- a/doc/storage-config-options.adoc
+++ b/doc/storage-config-options.adoc
@@ -17,6 +17,11 @@ metadata:
  # This will be used as name of PV Hosting Volume
   name: storage1
 spec:
+  tolerations:
+  - key: "key1"
+    operator: "Equal"
+    value: "value1"
+    effect: "NoSchedule"
   type: Replica1
   storage:
     - node: kube1
@@ -31,6 +36,10 @@ For now,
 
 The above 3 fields will be common for config files for all different modes.
 
+=== Tolerations
+
+* For `.spec.tolerations` refer link:https://github.com/kubernetes-client/python/blob/da6076/kubernetes/docs/V1Toleration.md[Toleration Spec]
+* These tolerations will get added to `server` pods and typical use-case includes usage of tainted nodes from which kadalu storage is created
 
 == Native mode
 

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -27,6 +27,17 @@ spec:
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/name: kadalu-csi-provisioner
     spec:
+{%- if tolerations %}
+      tolerations:
+  {%- for toleration in tolerations %}
+        - key: {{ toleration.get("key") }}
+          operator: {{ toleration.get("operator") }}
+          {%- if toleration.get("value") %}
+          value: {{ toleration.get("value") }}
+          {%- endif %}
+          effect: {{ toleration.get("effect") }}
+  {%- endfor %}
+{%- endif %}
       serviceAccountName: kadalu-csi-provisioner
       containers:
         - name: csi-provisioner


### PR DESCRIPTION
- Tolerations if supplied in KadaluStorage CR will make `server` pods
  run on those tainted nodes

fixes: #749, #867

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>