### PR TITLE
another round of multiple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support custom kubelet dir
 - Container images can now be built directly from the repository without dependencies on previous build steps
 - Enable and correctly handle tolerations supplied in KadaluStorage CR
+- Multiple fixes around handling deletions and metrics (#879)
 
 ## [0.8.15] - 2022-06-16
 

--- a/csi/exporter.py
+++ b/csi/exporter.py
@@ -41,10 +41,9 @@ def metrics():
     }
 
     if os.environ.get("CSI_ROLE", "-") == "nodeplugin":
-        pod_name_path = '/etc/hostname'
-        with open(pod_name_path, 'r') as pod_fd:
-            pod_name = pod_fd.read().strip()
-            data["pod"].update({"pod_name": pod_name})
+        # pool & pvc details can be read from provisioner
+        # avoid sending redundant data from nodeplugins
+        return data
 
     # Handle condition for no storage & PVC,
     # sometimes storage name is not shown at /mnt until server is mounted.

--- a/helm/kadalu/charts/operator/templates/deployment.yaml
+++ b/helm/kadalu/charts/operator/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         name: kadalu
+        app.kubernetes.io/part-of: kadalu
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8050"

--- a/helm/kadalu/charts/operator/templates/rbac.yaml
+++ b/helm/kadalu/charts/operator/templates/rbac.yaml
@@ -22,6 +22,13 @@ rules:
       - kadalustorages
     verbs:
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
 ---
 # CSI External Attacher
 # https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml

--- a/kadalu_operator/Dockerfile
+++ b/kadalu_operator/Dockerfile
@@ -13,6 +13,7 @@ FROM python:3.10-slim-bullseye as prod
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends procps && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/kadalu_operator/main.py
+++ b/kadalu_operator/main.py
@@ -531,11 +531,10 @@ def handle_added(core_v1_client, obj):
 
     if configmap_data.data.get("%s.info" % volname, None):
         # Volume already exists
-        logging.debug(logf(
-            "Ignoring already updated volume config",
+        logging.warning(logf(
+            "Updating existing config map",
             storagename=volname
         ))
-        return
 
     # Generate new Volume ID
     if obj["spec"].get("volume_id", None) is None:
@@ -709,45 +708,17 @@ def get_num_pvs(storage_info_data):
     """
 
     volname = storage_info_data['volname']
-    cmd = None
-    if storage_info_data.get("type") == "External":
-        # We can't access external cluster and so query existing PVs which are
-        # using external storageclass
-        volname = "kadalu." + volname
-        jpath = ('jsonpath=\'{range .items[?(@.spec.storageClassName=="%s")]}'
-                 '{.spec.storageClassName}{"\\n"}{end}\'' % volname)
-        cmd = ["kubectl", "get", "pv", "-o", jpath]
-    else:
-        bricks = storage_info_data['bricks']
-        dbpath = "/bricks/" + volname + "/data/brick/stat.db"
-        query = ("select count(pvname) from pv_stats;")
-        cmd = [
-            "kubectl", "exec", "-i",
-            bricks[0]['node'].replace("." + volname, ""), "-c", "server",
-            "-nkadalu", "--", "sqlite3", dbpath, query
-        ]
+    volname = "kadalu." + volname
+    jpath = ('jsonpath=\'{range .items[?(@.spec.storageClassName=="%s")]}'
+                '{.spec.storageClassName}{"\\n"}{end}\'' % volname)
+    cmd = ["kubectl", "get", "pv", "-o", jpath]
 
     try:
         resp = utils_execute(cmd)
-        parts = resp.stdout.strip("'").split()
-        if storage_info_data.get("type") == "External":
-            return len(parts)
-        pv_count = int(parts[0])
-        return pv_count
+        pvs = resp.stdout.strip("'").split()
+        return len(pvs)
 
     except CommandError as msg:
-        # 1. If storage is created but no PV is carved then pv_stats table is not
-        # created in SQLITE3
-        # 2. If we fail to create 'server' pod then there'll be no 'server'
-        # container (this'll be hit if supplied 'storageClass' is invalid)
-        # 3. If 'server' pod does not have a host assigned,
-        # TODO: find out root cause, repro - use incorrect device and edit with
-        # correct device later
-        if msg.stderr.find("no such table") != -1 or msg.stderr.find(
-                "container not found") != -1 or msg.stderr.find(
-                "not have a host assigned") != -1:
-            # We are good to delete server pods
-            return 0
         logging.error(
             logf("Failed to get size details of the "
                  "storage \"%s\"" % volname,

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -158,6 +158,13 @@ rules:
       - kadalustorages
     verbs:
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Attacher
@@ -361,6 +368,7 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:
@@ -370,6 +378,7 @@ spec:
     metadata:
       labels:
         name: kadalu
+        app.kubernetes.io/part-of: kadalu
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8050"

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -158,6 +158,13 @@ rules:
       - kadalustorages
     verbs:
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Attacher
@@ -361,6 +368,7 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:
@@ -370,6 +378,7 @@ spec:
     metadata:
       labels:
         name: kadalu
+        app.kubernetes.io/part-of: kadalu
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8050"

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -158,6 +158,13 @@ rules:
       - kadalustorages
     verbs:
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Attacher
@@ -361,6 +368,7 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:
@@ -370,6 +378,7 @@ spec:
     metadata:
       labels:
         name: kadalu
+        app.kubernetes.io/part-of: kadalu
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8050"

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -158,6 +158,13 @@ rules:
       - kadalustorages
     verbs:
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
 ---
 # Source: kadalu/charts/operator/templates/rbac.yaml
 # CSI External Attacher
@@ -361,6 +368,7 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
+    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:
@@ -370,6 +378,7 @@ spec:
     metadata:
       labels:
         name: kadalu
+        app.kubernetes.io/part-of: kadalu
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8050"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder /kadalu /kadalu
 RUN ln -sfn /usr/local/bin/python3 /kadalu/bin/python3
 
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends attr xfsprogs libtirpc3 sqlite3 liburcu6 && \
+    apt-get install -y --no-install-recommends attr xfsprogs libtirpc3 sqlite3 liburcu6 procps && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
csi:
- do not read pool & pvc details from nodeplugin for metrics collection
- ref: #852

manifests:
- add a new labels to operator to be able to get all pods which are part
  of kadalu using a single label

rbac:
- add missing rbac for listing persistentvolumes
- without this rbac the storageclasses weren't removed after pool
  deletion

dockerfile:
- install `procps` as part of building image
- for some reason `ps` isn't available in some of the component images,
  having `ps` will be quite handy for debugging rather than going into
  `/proc`

operator:
- only get the pods that are part of kadalu for metrics collection
- rename vars for better readability
- add empty `bricks` data for metrics collection of PVCs from external
  pools, ref: #869
- use same logic for finding presence of PVs from kadalu pools for both
  external and internal pools
- update configmap even in handle_added, since there's no finalizer pool
  CR can be removed for any reason and re-creation will not take into
  effect if we check for cm existence without updating
- without updating cm in handle_added, `volume_id` will never be used
  correctly incase of unintentional pool CR deletions

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>