### PR TITLE
replace with correct version while releasing manifests

### DIFF
--- a/helm/kadalu/charts/operator/templates/deployment.yaml
+++ b/helm/kadalu/charts/operator/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:

--- a/manifests/kadalu-operator-microk8s.yaml
+++ b/manifests/kadalu-operator-microk8s.yaml
@@ -368,7 +368,6 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:

--- a/manifests/kadalu-operator-openshift.yaml
+++ b/manifests/kadalu-operator-openshift.yaml
@@ -368,7 +368,6 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:

--- a/manifests/kadalu-operator-rke.yaml
+++ b/manifests/kadalu-operator-rke.yaml
@@ -368,7 +368,6 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:

--- a/manifests/kadalu-operator.yaml
+++ b/manifests/kadalu-operator.yaml
@@ -368,7 +368,6 @@ metadata:
     app.kubernetes.io/part-of: kadalu
     app.kubernetes.io/name: kadalu-operator
     app.kubernetes.io/component: operator
-    app.kubernetes.io/part-of: kadalu
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
- we are using `.Chart.Version` in subcharts for updating the corresponding value in the helm template
- however, it can only refer to it's own version and during release helm charts are correctly updated however yaml manifests are broken

fixes: #887

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>