### PR TITLE
fix flaky test after modifying pool cr

### DIFF
--- a/kadalu_operator/exporter.py
+++ b/kadalu_operator/exporter.py
@@ -32,7 +32,7 @@ def get_pod_data():
     """ Get pod and container info of all Pods in kadalu namespace """
 
     cmd = ["kubectl", "get", "pods", "-l", "app.kubernetes.io/part-of=kadalu",
-            "-nkadalu", "-ojson"]
+            "--field-selector=status.phase==Running", "-nkadalu", "-ojson"]
 
     try:
         resp = execute(cmd)

--- a/tests/minikube.sh
+++ b/tests/minikube.sh
@@ -23,7 +23,7 @@ function _log_msgs() {
   kubectl get kds --all-namespaces
   kubectl get sc --all-namespaces
   kubectl get pvc --all-namespaces
-  for p in $(kubectl -n kadalu get pods -o name); do
+  for p in $(kubectl -n kadalu get pods -o name --field-selector=status.phase==Running); do
     echo "====================== Start $p ======================"
     kubectl logs -nkadalu --all-containers=true --tail=$lines $p
     kubectl -nkadalu describe $p


### PR DESCRIPTION
- as the server pods are deployed via sts there'll be some delay before new pod status is running old pod vanishes completely
- in b/n this timespace the old server pod will be in terminating state and we need to skip accessing that

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>