### PR TITLE
conditionally build and push base builder image

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -18,19 +18,15 @@ jobs:
   devel-tag-push:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Check out Code
+      - name: Check out Code
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -50,14 +46,27 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/ci_merge-requirements.txt -e ./requirements
           KADALU_VERSION=devel make cli-build
 
+      - name: Check to build and push base image or not
+        id: build_base
+        run: |
+          # same conditions as mentioned in submit workflow
+          FILES=$(git show --pretty="" --name-only)
+          build_base='no'
+          if grep -e 'CHANGELOG.md' <<< "$b" && [ $(wc -w <<< "$b") == 1 ]; then
+            build_base='yes'
+          elif grep -e 'extras/Dockerfile.builder' <<< "$FILES"; then
+            build_base='yes'
+          fi
+          echo ::set-output name=out::$build_base
       - name: Builder Image
+        if: "contains(steps.build_base.outputs.build_base, 'yes')"
         uses: docker/build-push-action@v2
         timeout-minutes: 120
         with:
           context: .
           file: extras/Dockerfile.builder
           platforms: linux/amd64
-          push: false
+          push: true
           load: true
           tags: |
             docker.io/kadalu/builder:latest
@@ -66,8 +75,7 @@ jobs:
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
             KADALU_VERSION=${{ github.sha }}
-      -
-        name: Build CSI Image and push
+      - name: Build CSI Image and push
         uses: docker/build-push-action@v2
         timeout-minutes: 120
         with:
@@ -84,8 +92,7 @@ jobs:
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
             KADALU_VERSION=${{ github.sha }}
-      -
-        name: Build Operator Image and push
+      - name: Build Operator Image and push
         uses: docker/build-push-action@v2
         timeout-minutes: 20
         with:
@@ -102,8 +109,7 @@ jobs:
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
             KADALU_VERSION=${{ github.sha }}
-      -
-        name: Build Storage Server Image and push
+      - name: Build Storage Server Image and push
         uses: docker/build-push-action@v2
         timeout-minutes: 20
         with:
@@ -122,8 +128,7 @@ jobs:
             KADALU_VERSION=${{ github.sha }}
 
       # What follows are basically building and pushing of tests images conditionally
-      -
-        name: Check for Dockerfile changes in tests folder
+      - name: Check for Dockerfile changes in tests folder
         id: build_test
         run: |
           build_test='no'
@@ -133,8 +138,7 @@ jobs:
             build_test='yes'
           fi
           echo ::set-output name=build_test::$build_test
-      -
-        name: Build test-io image used in CI
+      - name: Build test-io image used in CI
         if: "contains(steps.build_test.outputs.build_test, 'yes')"
         uses: docker/build-push-action@v2
         timeout-minutes: 10
@@ -152,8 +156,7 @@ jobs:
             builddate=`date +%Y-%m-%d-%H:%M`
           secrets: |
             KADALU_VERSION=${{ github.sha }}
-      -
-        name: Build test-csi image used in CI
+      - name: Build test-csi image used in CI
         if: "contains(steps.build_test.outputs.build_test, 'yes')"
         uses: docker/build-push-action@v2
         timeout-minutes: 10

--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       files: ${{ steps.files.outputs.out }}
       msg: ${{ steps.msg.outputs.out }}
+      build_base: ${{ steps.build_base.outputs.out }}
     steps:
       - id: files
         run: |
@@ -32,6 +33,20 @@ jobs:
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits"
           MSG=$(curl -s -X GET -G $URL | jq -r '.[] | .commit.message')
           echo ::set-output name=out::$MSG
+      - id: build_base
+        env:
+          FILES: ${{ steps.files.outputs.out }}
+        run: |
+          BUILD_BASE="no"
+          # build base image if one of below conditions is met
+          # 1. if we have only CHANGELOG.md update (basically getting ready for a release)
+          if grep -e 'CHANGELOG.md' <<< "$b" && [ $(wc -w <<< "$b") == 1 ]; then
+            BUILD_BASE="yes"
+          # 2. if builder dockerfile is edited
+          elif grep -e 'extras/Dockerfile.builder' <<< "$FILES"; then
+            BUILD_BASE="yes"
+          fi
+          echo ::set-output name=out::$BUILD_BASE
 
   pylint:
     name: Run pylint
@@ -64,6 +79,7 @@ jobs:
       # No script currently uses COMMIT_MSG
       COMMIT_MSG: ${{needs.get-info.outputs.msg}}
       FILES: ${{needs.get-info.outputs.files}}
+      BUILD_BASE: ${{needs.get-info.outputs.build_base}}
     steps:
     - uses: actions/checkout@v2
     - name: Install Docker Dependencies
@@ -82,7 +98,7 @@ jobs:
     - name: Build locally
       id: build_local
       run: |
-        make build-containers;
+        BUILD_BASE="$BUILD_BASE" make build-containers;
 
         # Conditionally build test containers if PR includes tests/**/Dockerfile
         CONTAINERS_FOR=''

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DOCKER_USER?=kadalu
 KADALU_VERSION?=devel
 KADALU_LATEST?=latest
 DISTRO?=kubernetes
+BUILD_BASE?=yes
 
 help:
 	@echo "    make build-grpc        - To generate grpc Python Code"
@@ -23,7 +24,7 @@ build-grpc:
 	python3 -m grpc_tools.protoc -I./csi/protos --python_out=csi --grpc_python_out=csi ./csi/protos/csi.proto
 
 build-containers: cli-build
-	DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} bash build.sh
+	DOCKER_USER=${DOCKER_USER} KADALU_VERSION=${KADALU_VERSION} BUILD_BASE=${BUILD_BASE} bash build.sh
 
 # test-containers will be called on setting an environment variable 'CONTAINERS_FOR' as part of CI
 test-containers:

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -e -o pipefail
 
 DOCKER_USER="${DOCKER_USER:-kadalu}"
 KADALU_VERSION="${KADALU_VERSION}"
+BUILD_BASE=${BUILD_BASE:-yes}
 
 RUNTIME_CMD=${RUNTIME_CMD:-docker}
 # Use buildx for docker to simulate release script in github workflow
@@ -79,9 +80,14 @@ fi
 
 echo "Building base builder image - This may take a while"
 
-$RUNTIME_CMD $build \
-	     -t "${DOCKER_USER}/builder:latest" "${build_args[@]}" \
-	     --network host -f extras/Dockerfile.builder .
+if [ ${BUILD_BASE} == "yes" ]; then
+  $RUNTIME_CMD $build \
+        -t "${DOCKER_USER}/builder:latest" "${build_args[@]}" \
+        --network host -f extras/Dockerfile.builder .
+else
+  # pull the base image if we don't want to build it
+  $RUNTIME_CMD pull "${DOCKER_USER}/builder:latest"
+fi
 
 echo "Building kadalu-server with version tag as ${VERSION}";
 build_container "kadalu-server" "server/Dockerfile" ${KADALU_VERSION}


### PR DESCRIPTION
Gist:
- When specific conditions are met we are going to push base image while merging PR as well
- When specific conditions aren't met we are not going to build base image in every PR

Existing:
=========

on-pr-submit:
------------
1. unconditionally build base image for every pr and syncing of every pr
2. use the newly built image for component images

on-pr-merge:
------------
1. just build the base image for every image but no re-use in building component images

on-release-tag:
---------------
1. build and push base image which'll be used in building component images on-pr-merge

Current PR:
==========

on-pr-submit:
------------
1. build base image only if we are going for a release or builder Dockerfile is edited
2. in other cases pull the image

on-pr-merge:
------------
1. build and push base image only if we are going for a release or builder Dockerfile is edited
2. building and pushing of other component images will re-use this newly built image

on-release-tag:
---------------
1. build and push base image which'll be used in building component images on-pr-merge (no change)

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>