### PR TITLE
refactor ci flow and use existing tools from runner

### DIFF
--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.files.outputs.out }}
-      msg: ${{ steps.msg.outputs.out }}
       build_base: ${{ steps.build_base.outputs.out }}
     steps:
       - id: files
@@ -28,11 +27,6 @@ jobs:
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
           FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename')
           echo ::set-output name=out::$FILES
-      - id: msg
-        run: |
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits"
-          MSG=$(curl -s -X GET -G $URL | jq -r '.[] | .commit.message')
-          echo ::set-output name=out::$MSG
       - id: build_base
         env:
           FILES: ${{ steps.files.outputs.out }}
@@ -71,19 +65,16 @@ jobs:
       run: make pylint
 
   run-on-minikube:
-    name: kube 1.22.0
-    runs-on: ubuntu-latest
+    name: Kube Tests
+    # Refer https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md for all the
+    # tools that comes pre-installed with this runner
+    runs-on: ubuntu-22.04
     needs: get-info
     env:
-      KUBE_VERSION: v1.22.0
-      # No script currently uses COMMIT_MSG
-      COMMIT_MSG: ${{needs.get-info.outputs.msg}}
       FILES: ${{needs.get-info.outputs.files}}
       BUILD_BASE: ${{needs.get-info.outputs.build_base}}
     steps:
     - uses: actions/checkout@v2
-    - name: Install Docker Dependencies
-      run: sudo apt-get install -y conntrack ruby
     # CLI Tests
     - name: Install Binnacle and build kubectl-kadalu
       run: |
@@ -94,7 +85,6 @@ jobs:
         make cli-build
     - name: kubectl-kadalu Tests
       run: binnacle -v cli/tests/storage_add.t
-    # Build Containers
     - name: Build locally
       id: build_local
       run: |
@@ -113,23 +103,45 @@ jobs:
     - name: Generate Manifests
       run: VERBOSE="yes" make gen-manifest
 
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install -y conntrack socat --no-install-recommends
+        sudo mkdir -p /usr/local/bin
+
+        # Setup Docker shim for Minikube since it's deprecated as a runtime
+        CRI_DOCKERD_VERSION="0.2.5"
+        curl -sSfL https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar xzvf -
+        sudo install -o root -g root -m 0755 cri-dockerd/cri-dockerd /usr/local/bin/cri-dockerd
+        sudo curl -sSfL \
+          https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service \
+          -o /etc/systemd/system/cri-docker.service
+        sudo curl -sSfL \
+          https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket \
+          -o /etc/systemd/system/cri-docker.socket
+        sudo sed -i -e "s,/usr/bin/cri-dockerd,$(which cri-dockerd)," /etc/systemd/system/cri-docker.service
+        sudo systemctl daemon-reload
+        sudo systemctl enable cri-docker.service
+        sudo systemctl enable --now cri-docker.socket
+
+        CRICTL_VERSION="1.25.0"
+        curl -sSfL https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-amd64.tar.gz | tar xzvf -
+        sudo install -o root -g root -m 0755 crictl /usr/local/bin/crictl
+
     # Operator Tests
     - name: Setup Minikube
-      run: tests/setup.sh $KUBE_VERSION
+      run: sudo tests/minikube.sh up
     - name: Run tests
-      run: tests/travis-test.sh $KUBE_VERSION
+      run: tests/ci-test.sh
     - name: Cleanup
-      run: tests/cleanup.sh $KUBE_VERSION
+      run: sudo tests/minikube.sh clean
 
     # CLI Tests (run conditionally)
     - name: Setup Minikube (CLI Test)
-      run: |
-        sudo sysctl fs.protected_regular=0
-        tests/setup.sh $KUBE_VERSION
+      run: sudo tests/minikube.sh up
       if: "contains(needs.get-info.outputs.files, 'cli')"
     - name: Run tests (CLI Test)
-      run: tests/travis-test.sh $KUBE_VERSION cli
+      run: tests/ci-test.sh cli
       if: "contains(needs.get-info.outputs.files, 'cli')"
     - name: Cleanup (CLI Test)
-      run: tests/cleanup.sh $KUBE_VERSION
+      run: sudo tests/minikube.sh clean
       if: "contains(needs.get-info.outputs.files, 'cli')"

--- a/monitoring/exporter.py
+++ b/monitoring/exporter.py
@@ -1,1 +1,0 @@
-# Import Prometheus Python Client and start HTTP server

--- a/tests/ci-test.sh
+++ b/tests/ci-test.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 set -e
 
-# This script will be used by travis to run functional test
-# against different kuberentes version
-export KUBE_VERSION=$1
-
 cli_test="no"
-if [ "$#" -ge 2 -a "$2" == "cli" ]; then
+if [ "$#" -ge 1 -a "$1" == "cli" ]; then
     cli_test="yes"
 fi
 
-# pull docker images to speed up e2e
 if [ "$cli_test" == "no" ]; then
     echo "Starting YAML based tests (without CLI)"
     sudo tests/minikube.sh kadalu_operator
@@ -18,9 +13,5 @@ else
     echo "Starting CLI (kubectl kadalu) based tests"
     sudo tests/minikube.sh cli_tests
 fi
-
-#sudo chown -R travis: "$HOME"/.minikube /usr/local/bin/kubectl
-# functional tests
-# sample test
 
 sudo tests/minikube.sh test_kadalu

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# This script will be used by travis to run functional test
-# against different kuberentes version
-export KUBE_VERSION=$1
-
-sudo tests/minikube.sh clean

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-
-# This script will be used by travis to run functional test
-# against different kuberentes version
-export KUBE_VERSION=$1
-sudo tests/minikube.sh up


### PR DESCRIPTION
- don't install separate binaries and use them from github runner
- remove unused options wrt CI from minikube.sh
- didn't touch scripts as not sure of their usuage locally

ref: https://github.com/kadalu/kadalu/issues/866

Signed-off-by: Leela Venkaiah G <leelavg@thoughtexpo.com>