### PR TITLE
Add extra troubleshoot step to openshift monitoring doc

### DIFF
--- a/doc/openshift-monitoring.adoc
+++ b/doc/openshift-monitoring.adoc
@@ -147,7 +147,7 @@ $ oc -n kadalu  describe  services operator | awk '/Endpoints/ {print "http://"$
 - Go to the UI -> Administrator -> Observe -> Metrics -> Type "kadalu_" -> There should be multiple metrics
 
 
-- In case you got troubles with the Metrics, consider restarting the pods in the openshift-user-workload-monitoring namespace (and in rare cases openshift-monitoring)
+- In case you got troubles with the Metrics, consider setting "openshift.io/cluster-monitoring" to "false" and back to "true" or restarting the pods in the openshift-user-workload-monitoring namespace (and in rare cases openshift-monitoring)
 
 == Alarm configuration
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes Openshift monitoring doesn't show Kadalu endpoints in "Observe". Switching monitoring "off" (setting the label of the namespace to "false" and back to "true  ) and then "on" solves the problem.

Signed-off-by: hunter86bg <hunter86_bg@yahoo.com>