### PR TITLE
helm: Do not attempt to create the namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Helm chart: fixed namespace management bug
+
 ## [0.8.17] - 2022-10-17
 
 - Update Python modules dependencies for all components

--- a/helm/kadalu/charts/csi-nodeplugin/templates/namespace.yaml
+++ b/helm/kadalu/charts/csi-nodeplugin/templates/namespace.yaml
@@ -1,6 +1,0 @@
----
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: {{ .Release.Namespace }}
----


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the instructions in README file advise that Helm chart has been split into two subcharts. It then asks to deploy the Operator subchart first, followed by the csi-nodeplugin chart. Unfortunately, that second step always fails because, if the instructions are to be followed, the `kadalu` namespace is implicitly created in the first step when the operator is deployed. Helm refuses to install `cis-nodeplugin` subchart as the namespace already exists and it is not "owned" by the `csi-nodeplugin` subchart.

IMO it's best to leave the namespace management to the user, so that's what this PR does. I have tested that following the instructions from README file work correctly after the change.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added - N/A
- [ ] Tests updated - N/A
- [x] Add an entry in the `CHANGELOG.md` about the changes.
