### PR TITLE
Server: Mount FHS standardized kernel module /lib/modules rather than /usr/lib/modules

### DIFF
--- a/templates/server.yaml.j2
+++ b/templates/server.yaml.j2
@@ -112,7 +112,7 @@ spec:
 {%- if pvc_name == "" %}
         - name: gluster-kmods
           hostPath:
-            path: "/usr/lib/modules"
+            path: "/lib/modules"
 {%- endif %}
         - name: glusterfsd-volfilesdir
           configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
`/lib/modules` is most likely to exist on more systems than `/usr/lib/modules`. Example Talos.

**Which issue(s) this PR fixes**:
Fixes #904

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added => not required
- [ ] Tests updated => not required
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
=> I thought changelog is generated from PR title : P. Let me know if I should add something.
