### PR TITLE
Build: use latest glusterfs

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -14,7 +14,7 @@ RUN python3 -m pip install $(grep -vE '^(grpcio|\s*#)' /tmp/csi-requirements.txt
 FROM python:3.10-slim-bullseye as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends sqlite3 xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 && \
+    apt-get install -y --no-install-recommends sqlite3 xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 libgoogle-perftools4 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -11,9 +11,10 @@ RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends curl xfsprogs net-tools telnet wget e2fsprogs zlib1g-dev liburcu6\
     sqlite3 build-essential g++ flex bison openssl libssl-dev libtirpc-dev liburcu-dev \
     libfuse-dev libuuid1 uuid-dev acl-dev libtool automake autoconf git pkg-config \
-    libffi-dev && \
+    libffi-dev google-perftools libgoogle-perftools-dev libtcmalloc-minimal4 libgoogle-perftools4 && \
     git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
-    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt >/dev/null && make install >/dev/null && cd ..) && \
+    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt --disable-linux-io_uring --enable-tcmalloc --disable-mempool >/dev/null && \
+    make install >/dev/null && cd ..) && \
     curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/`uname -m | sed 's|aarch64|arm64|' | sed 's|x86_64|amd64|' | sed 's|armv7l|arm|'`/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
 

--- a/extras/Dockerfile.builder
+++ b/extras/Dockerfile.builder
@@ -1,6 +1,6 @@
 FROM python:3.10-bullseye
 
-ARG branch="series_1"
+ARG branch="kadalu_1"
 
 ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder /kadalu /kadalu
 RUN ln -sfn /usr/local/bin/python3 /kadalu/bin/python3
 
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends attr xfsprogs libtirpc3 sqlite3 liburcu6 procps && \
+    apt-get install -y --no-install-recommends attr xfsprogs libtirpc3 sqlite3 liburcu6 procps libgoogle-perftools4 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
glusterfs project just did the branching for `release-11.0` version, and kadalu projects will use this as the base in its projects too.

Signed-off-by: Amar Tumballi <amar@dhiway.com>
