### PR TITLE
Remove default tiebreaker node and add support for Replica2

### DIFF
--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -141,8 +141,6 @@ def validate(args):
                 "in the format <node>:/<path>",
                 file=sys.stderr)
             sys.exit(1)
-    else:
-        args.tiebreaker = "tie-breaker.kadalu.io:/mnt"
 
     if not args.type:
         args.type = "Replica1"
@@ -333,7 +331,7 @@ def storage_add_data(args):
             content["spec"]["storage"].append({"pvc": pvc})
 
     # TODO: Support for different port can be added later
-    if args.type == "Replica2":
+    if args.type == "Replica2" and args.tiebreaker is not None:
         node, path = args.tiebreaker.split(":", 1)
         content["spec"]["tiebreaker"] = {
             "node": node,

--- a/cli/tests/storage_add.t
+++ b/cli/tests/storage_add.t
@@ -133,10 +133,6 @@ spec:
       path: "/exports/sp1/s1"
     - node: "server2.example.com"
       path: "/exports/sp1/s2"
-  tiebreaker:
-    node: "tie-breaker.kadalu.io"
-    path: "/mnt"
-    port: 24007
 
 )
 
@@ -163,10 +159,6 @@ spec:
       device: "/dev/vdc"
     - node: "server2.example.com"
       device: "/dev/vdc"
-  tiebreaker:
-    node: "tie-breaker.kadalu.io"
-    path: "/mnt"
-    port: 24007
 
 )
 
@@ -191,10 +183,6 @@ spec:
   storage:
     - pvc: "pvc1"
     - pvc: "pvc2"
-  tiebreaker:
-    node: "tie-breaker.kadalu.io"
-    path: "/mnt"
-    port: 24007
 
 )
 
@@ -512,10 +500,6 @@ spec:
       path: "/exports/sp1/s3"
     - node: "server4.example.com"
       path: "/exports/sp1/s4"
-  tiebreaker:
-    node: "tie-breaker.kadalu.io"
-    path: "/mnt"
-    port: 24007
 
 )
 
@@ -546,10 +530,6 @@ spec:
       device: "/dev/vdc"
     - node: "server4.example.com"
       device: "/dev/vdc"
-  tiebreaker:
-    node: "tie-breaker.kadalu.io"
-    path: "/mnt"
-    port: 24007
 
 )
 
@@ -562,7 +542,7 @@ EQUAL expected, actual, "Distributed Replica2 with alternate syntax and --storag
 actual = TEST "#{cmd} storage-add --dry-run sp1 replica 2 server1.example.com:/dev/vdc server2.example.com:/dev/vdc server3.example.com:/dev/vdc server4.example.com:/dev/vdc --storage-unit-type=device"
 EQUAL expected, actual, "Distributed Replica2 with alternate syntax 2 and --storage-unit-type=device"
 
-# Replica2 with pvc
+# Replica2 with pvc and tiebreaker
 expected = %(Storage Yaml file for your reference:
 
 apiVersion: "kadalu-operator.storage/v1alpha1"
@@ -580,6 +560,26 @@ spec:
     node: "tie-breaker.kadalu.io"
     path: "/mnt"
     port: 24007
+
+)
+
+actual = TEST "#{cmd} storage-add --dry-run sp1 --type=Replica2 --pvc pvc1 --pvc pvc2 --pvc pvc3 --pvc pvc4 --tiebreaker tie-breaker.kadalu.io:/mnt"
+EQUAL expected, actual, "Distributed Replica2 with --pvc and tiebreaker"
+
+# Replica2 with pvc
+expected = %(Storage Yaml file for your reference:
+
+apiVersion: "kadalu-operator.storage/v1alpha1"
+kind: "KadaluStorage"
+metadata:
+  name: "sp1"
+spec:
+  type: "Replica2"
+  storage:
+    - pvc: "pvc1"
+    - pvc: "pvc2"
+    - pvc: "pvc3"
+    - pvc: "pvc4"
 
 )
 

--- a/doc/storage-config-options.adoc
+++ b/doc/storage-config-options.adoc
@@ -59,7 +59,7 @@ $ kubectl kadalu storage-add storage-pool1 --type=Replica1 \
 +
 To create a PVC from this storage, you need to provide `storageClassName` option as `kadalu.replica1`.
 
-* **Replica2** In this mode, Gluster will be started with high availability, with 'tie-breaker' (or thin-arbiter in gluster speak) option. It will use 2 storage options, from which the RWX and RWO PVs will be carved out. This storage will be exposed by a gluster server pod, which gets spawned by kadalu operator. The `tiebreaker` node has to be managed outside, and if the user doesn't want to host it, kadalu provides a free service for the same, which can be consumed by not providing any `tiebreaker` option :-)
+* **Replica2** In this mode, Gluster will be started with high availability, with 'tie-breaker' (or thin-arbiter in gluster speak) option. It will use 2 storage options, from which the RWX and RWO PVs will be carved out. This storage will be exposed by a gluster server pod, which gets spawned by kadalu operator. The `tiebreaker` node has to be managed outside, and if the tiebreaker option is not provided, Kadalu creates the Replica 2 Volume without Tiebreaker.
 +
 [source,yaml]
 ----

--- a/kadalu_operator/main.py
+++ b/kadalu_operator/main.py
@@ -321,10 +321,6 @@ def upgrade_storage_pods(core_v1_client):
             obj["spec"]["storage"][idx]["device"] = val["brick_device"]
             obj["spec"]["storage"][idx]["pvc"] = val["pvc_name"]
 
-        if data['type'] == VOLUME_TYPE_REPLICA_2:
-            if "tie-breaker.kadalu.io" not in data['tiebreaker']['node']:
-                obj["spec"]["tiebreaker"] = data['tiebreaker']
-
         # TODO: call upgrade_pods_with_heal_check() here
         deploy_server_pods(obj)
 
@@ -378,18 +374,12 @@ def update_config_map(core_v1_client, obj):
     if voltype == VOLUME_TYPE_REPLICA_2:
         tiebreaker = obj["spec"].get("tiebreaker", None)
         if not tiebreaker:
-            logging.warning(logf("No 'tiebreaker' provided for replica2 "
-                                 "config. Using default tie-breaker.kadalu.io:/mnt",
-                                 volname=volname))
-            # Add default tiebreaker if no tie-breaker option provided
-            tiebreaker = {
-                "node": "tie-breaker.kadalu.io",
-                "path": "/mnt",
-            }
-        if not tiebreaker.get("port", None):
-            tiebreaker["port"] = 24007
+            data["tiebreaker"] = {}
+        else:
+            if not tiebreaker.get("port", None):
+                tiebreaker["port"] = 24007
 
-        data["tiebreaker"] = tiebreaker
+            data["tiebreaker"] = tiebreaker
 
     volinfo_file = "%s.info" % volname
     configmap_data.data[volinfo_file] = json.dumps(data)

--- a/templates/Replica2.client.vol.j2
+++ b/templates/Replica2.client.vol.j2
@@ -1,3 +1,4 @@
+{% if tiebreaker %}
 volume {{ volume_id }}-ta
     type protocol/client
     option transport.socket.read-fail-log false
@@ -5,6 +6,7 @@ volume {{ volume_id }}-ta
     option remote-port {{ tiebreaker["port"] }}
     option remote-subvolume {{ tiebreaker["path"] }}
 end-volume
+{% endif %}
 
 {% for brick in bricks %}
 volume {{ volname }}-client-{{ brick["brick_index"] }}
@@ -26,9 +28,14 @@ volume {{ volname }}-replica-{{ i }}
     option metadata-self-heal on
     option entry-self-heal on
     option read-hash-mode 5
+    {% if tiebreaker %}
     option afr-pending-xattr {{ volname }}-client-{{ i * 2 }},{{ volname }}-client-{{ (i * 2) + 1}},{{ volume_id }}-ta
     option thin-arbiter {{ tiebreaker["node"] }}:{{ tiebreaker["path"] }}
     subvolumes {{ volname }}-client-{{ i * 2 }} {{ volname }}-client-{{ (i * 2) + 1}} {{ volume_id }}-ta
+    {% else %}
+    option afr-pending-xattr {{ volname }}-client-{{ i * 2 }},{{ volname }}-client-{{ (i * 2) + 1}}
+    subvolumes {{ volname }}-client-{{ i * 2 }} {{ volname }}-client-{{ (i * 2) + 1}}
+    {% endif %}
 end-volume
 
 {% endfor %}

--- a/templates/Replica2.shd.vol.j2
+++ b/templates/Replica2.shd.vol.j2
@@ -1,3 +1,4 @@
+{% if tiebreaker %}
 volume {{ volume_id }}-ta
     type protocol/client
     option transport.socket.read-fail-log false
@@ -5,6 +6,7 @@ volume {{ volume_id }}-ta
     option remote-port {{ tiebreaker["port"] }}
     option remote-subvolume {{ tiebreaker["path"] }}
 end-volume
+{% endif %}
 
 {% for brick in bricks %}
 volume {{ volname }}-client-{{ brick["brick_index"] }}
@@ -33,9 +35,14 @@ volume {{ volname }}-replica-{{ i }}
     option entry-change-log on
     option metadata-change-log on
     option read-hash-mode 5
+    {% if tiebreaker %}
     option afr-pending-xattr {{ volname }}-client-{{ i * 2 }},{{volname }}-client-{{(i * 2) + 1}},{{ volume_id }}-ta
     option thin-arbiter {{ tiebreaker["node"] }}:{{ tiebreaker["path"] }}
     subvolumes {{ volname }}-client-{{ i * 2 }} {{ volname }}-client-{{ (i * 2) + 1}} {{ volume_id }}-ta
+    {% else %}
+    option afr-pending-xattr {{ volname }}-client-{{ i * 2 }},{{volname }}-client-{{(i * 2) + 1}}
+    subvolumes {{ volname }}-client-{{ i * 2 }} {{ volname }}-client-{{ (i * 2) + 1}}
+    {% endif %}
 end-volume
 
 {% endfor %}


### PR DESCRIPTION
- Default tiebreaker node `tie-breaker.kadalu.io` is removed
- If tiebreaker node is not provided, create regular Replica 2 Volume without Tiebreaker.
- Add Tiebreaker Volume support when Tiebreaker details provided with Replica 2 volumes.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>
