### PR TITLE
csi: Implement logrotate to free-up space used by logs

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -14,11 +14,7 @@ RUN python3 -m pip install $(grep -vE '^(grpcio|\s*#)' /tmp/csi-requirements.txt
 FROM python:3.10-slim-bullseye as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
-<<<<<<< HEAD
-    apt-get install -y --no-install-recommends sqlite3 psmisc logrotate xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 && \
-=======
     apt-get install -y --no-install-recommends sqlite3 psmisc logrotate xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 libgoogle-perftools4 && \
->>>>>>> f580e772713b26faa705ce1e953a4521e183f1e0
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -14,7 +14,7 @@ RUN python3 -m pip install $(grep -vE '^(grpcio|\s*#)' /tmp/csi-requirements.txt
 FROM python:3.10-slim-bullseye as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends sqlite3 xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 && \
+    apt-get install -y --no-install-recommends sqlite3 psmisc logrotate xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -49,6 +49,9 @@ COPY csi/quota-crawler.sh      /kadalu/
 COPY csi/watch-vol-changes.sh  /kadalu/
 COPY csi/heal-info.sh          /kadalu/
 COPY csi/remove_archived_pv.py /kadalu/
+COPY csi/watch-logrotate.sh    /kadalu/
+
+COPY extras/kadalu-logrotate.conf     /kadalu/logrotate.conf
 
 COPY templates/Replica1.client.vol.j2 /kadalu/templates/
 COPY templates/Replica2.client.vol.j2 /kadalu/templates/

--- a/csi/start.py
+++ b/csi/start.py
@@ -11,6 +11,7 @@ def main():
     mon.add_process(Proc("csi", "python3", [curr_dir + "/main.py"]))
     mon.add_process(Proc("metrics", "python3", [curr_dir + "/exporter.py"]))
     mon.add_process(Proc("volumewatch", "bash", [curr_dir + "/watch-vol-changes.sh"]))
+    mon.add_process(Proc("kadalu-logrotate", "bash", [curr_dir + "/watch-logrotate.sh"]))
 
     if os.environ.get("CSI_ROLE", "-") == "provisioner":
         mon.add_process(Proc("quota", "bash", [curr_dir + "/quota-crawler.sh"]))

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1277,6 +1277,7 @@ def mount_glusterfs(volume, mountpoint, storage_options="", is_client=False):
             GLUSTERFS_CMD,
             "--process-name", "fuse",
             "-l", log_file,
+            "-L", "DEBUG",
             "--volfile-id", volname,
             "--fs-display-name", "kadalu:%s" % volname,
             "-f", client_volfile_path,

--- a/csi/watch-logrotate.sh
+++ b/csi/watch-logrotate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 while true
 do
-  if [[ $(ls /var/log/gluster/*.gz | wc -l) -ge 9 ]]; then
+  if [[ $(ls /var/log/gluster/*.gz | wc -l) -ge 4 ]]; then
     rm -rf /var/log/gluster/*.gz
   fi
   logrotate /kadalu/logrotate.conf

--- a/csi/watch-logrotate.sh
+++ b/csi/watch-logrotate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 while true
 do
-  if [[ $(ls /var/log/gluster/*.gz | wc -l) -ge 4 ]]; then
+  if [[ $(ls /var/log/gluster/*.gz | wc -l) -ge 3 ]]; then
     rm -rf /var/log/gluster/*.gz
   fi
   logrotate /kadalu/logrotate.conf

--- a/csi/watch-logrotate.sh
+++ b/csi/watch-logrotate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+while true
+do
+  if [[ $(ls /var/log/gluster/*.gz | wc -l) -ge 9 ]]; then
+    rm -rf /var/log/gluster/*.gz
+  fi
+  logrotate /kadalu/logrotate.conf
+  /usr/bin/killall -HUP glusterfs > /dev/null 2>&1 || true
+  # Run logrotate for every 8 hours
+  sleep 28800
+done

--- a/csi/watch-logrotate.sh
+++ b/csi/watch-logrotate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+while true
+do
+  if [[ $(ls *.gz | wc -l) -ge 9 ]]; then
+    rm -rf /var/log/gluster/*.gz
+  fi
+  logrotate /kadalu/logrotate.conf
+  /usr/bin/killall -HUP glusterfs > /dev/null 2>&1 || true
+  # Run logrotate for every 8 hours
+  sleep 28800
+done

--- a/extras/kadalu-logrotate.conf
+++ b/extras/kadalu-logrotate.conf
@@ -1,0 +1,14 @@
+/var/log/gluster/*.log {
+  su root root
+  sharedscripts
+  maxsize 10M
+  minsize 100k
+  rotate 10
+  missingok
+  compress
+  delaycompress
+  notifempty
+  postrotate
+  /usr/bin/killall -HUP glusterfs > /dev/null 2>&1 || true
+  endscript
+}

--- a/extras/kadalu-logrotate.conf
+++ b/extras/kadalu-logrotate.conf
@@ -3,7 +3,7 @@
   sharedscripts
   maxsize 10M
   minsize 100k
-  rotate 10
+  rotate 4
   missingok
   compress
   delaycompress

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -150,6 +150,7 @@ def execute(*cmd):
     with subprocess.Popen(cmd,
                           stderr=subprocess.PIPE,
                           stdout=subprocess.PIPE,
+                          cwd=None,
                           universal_newlines=True) as proc:
         out, err = proc.communicate()
         if proc.returncode != 0:

--- a/manifests/csi-nodeplugin-microk8s.yaml
+++ b/manifests/csi-nodeplugin-microk8s.yaml
@@ -120,7 +120,7 @@ spec:
         - name: kadalu-logging
           image: docker.io/library/busybox
           command: ["/bin/sh"]
-          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -f /var/log/gluster/*.log"]
+          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -F /var/log/gluster/*.log"]
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"

--- a/manifests/csi-nodeplugin-openshift.yaml
+++ b/manifests/csi-nodeplugin-openshift.yaml
@@ -120,7 +120,7 @@ spec:
         - name: kadalu-logging
           image: docker.io/library/busybox
           command: ["/bin/sh"]
-          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -f /var/log/gluster/*.log"]
+          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -F /var/log/gluster/*.log"]
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"

--- a/manifests/csi-nodeplugin-rke.yaml
+++ b/manifests/csi-nodeplugin-rke.yaml
@@ -120,7 +120,7 @@ spec:
         - name: kadalu-logging
           image: docker.io/library/busybox
           command: ["/bin/sh"]
-          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -f /var/log/gluster/*.log"]
+          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -F /var/log/gluster/*.log"]
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"

--- a/manifests/csi-nodeplugin.yaml
+++ b/manifests/csi-nodeplugin.yaml
@@ -120,7 +120,7 @@ spec:
         - name: kadalu-logging
           image: docker.io/library/busybox
           command: ["/bin/sh"]
-          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -f /var/log/gluster/*.log"]
+          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -F /var/log/gluster/*.log"]
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"

--- a/templates/csi.yaml.j2
+++ b/templates/csi.yaml.j2
@@ -115,7 +115,7 @@ spec:
         - name: kadalu-logging
           image: {{ images_hub }}/library/busybox
           command: ["/bin/sh"]
-          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -f /var/log/gluster/*.log"]
+          args: ["-c", "while true; do logcnt=$(/bin/ls /var/log/gluster/ | wc -l); if [ ${logcnt} -gt 0 ]; then break; fi; sleep 5; done; tail -F /var/log/gluster/*.log"]
           volumeMounts:
             - name: varlog
               mountPath: "/var/log/gluster"


### PR DESCRIPTION
This PR implements logrotate into kadalu's CSI POD to free-up space used by logs periodically.
The logs will be rotated when minsize of 100KB, maxsize of 10MB will be reached. 
Atmost of 10 log archives will be available in logging directory. 
The logrotate executable is triggered by watch-logrotate.sh process which will execute it every 8 hours.

Fixes: #914 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>

