### PR TITLE
Disable armv7 release builds

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           context: .
           file: extras/Dockerfile.builder
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           no-cache: true
           tags: |
@@ -138,7 +138,7 @@ jobs:
         with:
           context: .
           file: csi/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           target: prod
           push: true
           no-cache: true
@@ -158,7 +158,7 @@ jobs:
         with:
           context: .
           file: server/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           target: prod
           push: true
           no-cache: true
@@ -178,7 +178,7 @@ jobs:
         with:
           context: .
           file: kadalu_operator/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           target: prod
           push: true
           no-cache: true


### PR DESCRIPTION
Gluster stopped supporting 32 bit platforms.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>
