### PR TITLE
CSI: Fix remove_archived_pvs using method wrong

### DIFF
--- a/csi/remove_archived_pv.py
+++ b/csi/remove_archived_pv.py
@@ -11,7 +11,12 @@ def get_archived_pvs(storage_name, pvc_name):
     """ Return all or specified archived_pvcs based on agrs """
 
     archived_pvs = {}
-    mntdir = os.path.join(HOSTVOL_MOUNTDIR, storage_name)
+
+    mntdir = os.path.join(HOSTVOL_MOUNTDIR, storage_name, "info")
+    if not os.path.isdir(mntdir):
+        sys.stderr.write(f"Metadata for storagepool {storage_name} is not found")
+        return -1
+
     try:
         for pvc in yield_pvc_from_mntdir(mntdir):
             if pvc is not None:


### PR DESCRIPTION



<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**: Using `yield_pvc_from_mntdir` seems dangerous as it does not provide any safeguards against passing wrong paths.
Instead use safer method `yield_pvc_from_hostvol` and extend that method to accept filters.

**Which issue(s) this PR fixes**: Fixes #912 
Fixes #<issue number>

**Special notes for your reviewer**: Should we get rid of `yield_pvc_from_mntdir`??? It seems unsafe. Instead, the functionality could be integrated into `yield_pvc_from_hostvol` (it is the only function that uses it anyway (apart from one in `csi/exporter.py` which can be rewritten to use the safer `yield_pvc_from_hostvol`).

**Checklist**
- (not required) Documentation added
- (not required) Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes. => WILL do once PR discussion complete!
