### PR TITLE
server: Use Kadalu Volgen library for volfile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Server: Use Kadalu Volgen library for volfile generation
+
 ## [0.9.0] - 2022-11-21
 
 - Helm chart: fixed namespace management bug

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,9 +24,11 @@ COPY --from=builder /kadalu /kadalu
 RUN ln -sfn /usr/local/bin/python3 /kadalu/bin/python3
 
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends attr xfsprogs libtirpc3 sqlite3 liburcu6 procps libgoogle-perftools4 && \
+    apt-get install -y --no-install-recommends curl attr xfsprogs libtirpc3 sqlite3 liburcu6 procps libgoogle-perftools4 && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://github.com/kadalu/volgen/releases/latest/download/install.sh | bash -x
 
 RUN mkdir -p /kadalu/templates /kadalu/volfiles
 RUN mkdir -p /var/run/gluster /var/log/glusterfs
@@ -39,16 +41,7 @@ COPY server/mount-glustervol /usr/bin/mount-glustervol
 COPY lib/startup.sh          /kadalu/startup.sh
 COPY server/stop-server.sh   /kadalu/stop-server.sh
 COPY server/exporter.py      /kadalu/exporter.py
-
-# Copy Volfile templates
-COPY templates/Replica1.client.vol.j2 /kadalu/templates/
-COPY templates/Replica2.client.vol.j2 /kadalu/templates/
-COPY templates/Replica3.client.vol.j2 /kadalu/templates/
-COPY templates/Disperse.client.vol.j2 /kadalu/templates/
-COPY templates/Replica2.shd.vol.j2    /kadalu/templates/
-COPY templates/Replica3.shd.vol.j2    /kadalu/templates/
-COPY templates/Disperse.shd.vol.j2    /kadalu/templates/
-COPY templates/brick.vol.j2           /kadalu/templates/
+COPY server/serverutils.py   /kadalu/serverutils.py
 
 RUN chmod +x /usr/bin/mount-glustervol
 RUN chmod +x /kadalu/startup.sh

--- a/server/glusterfsd.py
+++ b/server/glusterfsd.py
@@ -209,7 +209,7 @@ def start_args():
 
     volfile_id = "%s.%s.%s" % (volname, nodename, brick_path_name)
     storage_unit_volfile_path = os.path.join(VOLFILES_DIR, "%s.vol" % volfile_id)
-    client_volfile_path = os.path.join(VOLFILES_DIR, "%s.client.vol" % volname)
+    client_volfile_path = os.path.join(VOLFILES_DIR, "%s.vol" % volname)
     create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_path)
     create_client_volfile(client_volfile_path, volname)
 

--- a/server/mount-glustervol
+++ b/server/mount-glustervol
@@ -5,8 +5,9 @@ import json
 
 from jinja2 import Template
 
+from serverutils import generate_client_volfile
+
 info_dir = "/var/lib/gluster"
-templates_dir = "/kadalu/templates"
 volfiles_dir = "/kadalu/volfiles"
 
 volname = sys.argv[1]
@@ -16,43 +17,11 @@ data = {}
 with open(info_file) as f:
     data = json.load(f)
 
-# Tricky to get this right, but this solves all the elements of distribute in code :-)
-data['dht_subvol'] = []
-decommissioned = []
-if data["type"] == "Replica1":
-    for brick in data["bricks"]:
-        brick_name = "%s-client-%d" % (data["volname"], brick["brick_index"])
-        data["dht_subvol"].append(brick_name)
-        if brick.get("decommissioned", "") != "":
-            decommissioned.append(brick_name)
+client_volfile_path = os.path.join(volfiles_dir, "%s.client.vol" % volname)
 
-else:
-    count = 3
-    if data["type"] == "Replica2":
-        count = 2
-    if data["type"] == "Disperse":
-        count = data["disperse"]["data"] + data["disperse"]["redundancy"]
-        data["disperse_redundancy"] = data["disperse"]["redundancy"]
-
-    for i in range(0, int(len(data["bricks"]) / count)):
-        brick_name = "%s-%s-%d" % (
-            data["volname"],
-            "disperse" if data["type"] == "Disperse" else "replica",
-            i
-        )
-        data["dht_subvol"].append(brick_name)
-        if data["bricks"][(i * count)].get("decommissioned", "") != "":
-            decommissioned.append(brick_name)
-
-data['decommissioned'] = "" if decommissioned == [] else ",".join(decommissioned)
-
-template_file = os.path.join(templates_dir, "%s.client.vol" % data["type"])
-client_volfile = os.path.join(volfiles_dir, "%s.client.vol" % volname)
-content = ""
-with open(template_file) as f:
-    content = f.read()
-
-Template(content).stream(**data).dump(client_volfile)
+content = generate_client_volfile(data)
+with open(client_volfile_path, "w") as client_volfile:
+    client_volfile.write(content)
 
 os.makedirs("/mnt/%s" % volname)
 
@@ -63,7 +32,7 @@ os.execv(
         "--process-name", "fuse",
         "--volfile-id=%s" % volname,
         "--fs-display-name", "kadalu:%s" % volname,
-        "-f", client_volfile,
+        "-f", client_volfile_path,
         "/mnt/%s" % volname
     ]
 )

--- a/server/mount-glustervol
+++ b/server/mount-glustervol
@@ -3,25 +3,21 @@ import os
 import sys
 import json
 
-from jinja2 import Template
-
 from serverutils import generate_client_volfile
 
-info_dir = "/var/lib/gluster"
-volfiles_dir = "/kadalu/volfiles"
+INFO_DIR = "/var/lib/gluster"
+VOLFILES_DIR= "/kadalu/volfiles"
 
 volname = sys.argv[1]
 
-info_file = os.path.join(info_dir, "%s.info" % volname)
+info_file = os.path.join(INFO_DIR, "%s.info" % volname)
 data = {}
 with open(info_file) as f:
     data = json.load(f)
 
-client_volfile_path = os.path.join(volfiles_dir, "%s.client.vol" % volname)
+client_volfile_path = os.path.join(VOLFILES_DIR, "%s.client.vol" % volname)
 
-content = generate_client_volfile(data)
-with open(client_volfile_path, "w") as client_volfile:
-    client_volfile.write(content)
+generate_client_volfile(data, client_volfile_path)
 
 os.makedirs("/mnt/%s" % volname)
 

--- a/server/serverutils.py
+++ b/server/serverutils.py
@@ -1,0 +1,97 @@
+import os
+import kadalu_volgen
+
+VOLFILES_DIR = "/var/lib/kadalu/volfiles"
+
+if not os.path.exists(VOLFILES_DIR):
+    os.makedirs(VOLFILES_DIR)
+
+def generate_client_volgen_data(data):
+    """
+    Create and return client volgen data, which is parsed by
+    Kadalu Volgen library for creation of Client &
+    Self-Heal Daemon(SHD) volfiles.
+
+    Client volgen data is created by calculating number of distribute
+    groups and storage units in each distribute group.
+    Then slicing bricks data(Created using storgae pool info based on configmap)
+    into respective distribute groups.
+    """
+
+    # No of distribute groups in a volume
+    dist_grp_count = 0
+    # No of storage units in a distribute group
+    storage_unit_count = 0
+    replica_count = 0
+
+    get_replica_count = {
+        "Replica1" : 1,
+        "Replica2" : 2,
+        "Replica3" : 3
+    }
+
+    if data["type"] == "Disperse":
+        storage_unit_count = data["disperse"]["data"] + data["disperse"]["redundancy"]
+        replica_count = 0
+    else:
+        storage_unit_count = replica_count = get_replica_count.get(data["type"], "")
+
+    client_data = {}
+    client_data["name"] = data["volname"]
+    client_data["id"] = data["volume_id"]
+
+    dist_grp_count = int((len(data["bricks"]) / storage_unit_count))
+    client_data["distribute_groups"] = [{} for _ in range(dist_grp_count)]
+
+    for dist_grp_idx, dist_grp in enumerate(client_data["distribute_groups"]):
+        if "Replica" in data["type"]:
+            dist_grp["type"] = "replica"
+        else:
+            dist_grp["type"] = "disperse"
+
+        dist_grp["replica_count"] = replica_count
+        dist_grp["storage_units"] = [{} for _ in range(storage_unit_count)]
+
+        for storage_unit_idx, storage_unit in enumerate(dist_grp["storage_units"]):
+            brick_idx = (dist_grp_idx * storage_unit_count + storage_unit_idx)
+            storage_unit["path"] = data["bricks"][brick_idx].get("brick_path", "")
+            storage_unit["port"] = 24007
+            storage_unit["node"] = {
+                "name" : data["bricks"][brick_idx].get("node", ""),
+                "id" : data["bricks"][brick_idx].get("node_id", "")
+            }
+
+    return client_data
+
+def generate_brick_volfile(storage_unit, storage_unit_volfile_path):
+    """ Generate brick/storage_unit volfile using Kadalu Volgen library"""
+
+    kadalu_volgen.generate(
+        "/var/lib/kadalu/templates/storage_unit.vol.j2",
+        data=storage_unit,
+        output_file=storage_unit_volfile_path
+    )
+
+
+def generate_shd_volfile(data, shd_volfile_path):
+    """ Generate Self-Heal-Daemon(SHD) volfile using Kadalu Volgen library"""
+
+    client_data = generate_client_volgen_data(data)
+
+    kadalu_volgen.generate(
+        "/var/lib/kadalu/templates/shd.vol.j2",
+        data=client_data,
+        output_file=shd_volfile_path
+    )
+
+
+def generate_client_volfile(data, client_volfile_path):
+    """ Generate client volfile using Kadalu Volgen library"""
+
+    client_data = generate_client_volgen_data(data)
+
+    kadalu_volgen.generate(
+        "/var/lib/kadalu/templates/client.vol.j2",
+        data=client_data,
+        output_file=client_volfile_path
+    )

--- a/server/serverutils.py
+++ b/server/serverutils.py
@@ -1,10 +1,6 @@
 import os
 import kadalu_volgen
 
-VOLFILES_DIR = "/var/lib/kadalu/volfiles"
-
-if not os.path.exists(VOLFILES_DIR):
-    os.makedirs(VOLFILES_DIR)
 
 def generate_client_volgen_data(data):
     """

--- a/server/shd.py
+++ b/server/shd.py
@@ -4,16 +4,14 @@ Starts Gluster Brick Self Heal Daemon(shd) process
 import json
 import os
 
-from jinja2 import Template
 from kadalulib import Proc
-
 from serverutils import generate_shd_volfile
 
-VOLFILES_DIR = "/kadalu/volfiles"
+VOLFILES_DIR = "/var/lib/kadalu/volfiles"
 VOLINFO_DIR = "/var/lib/gluster"
 
 
-def create_shd_volfile(shd_volfile_path, volname, voltype):
+def create_shd_volfile(shd_volfile_path, volname):
     """
     Generate Self Heal Daemon(SHD) Volfile for Glusterfs
     Volume of type Replica2.
@@ -24,9 +22,7 @@ def create_shd_volfile(shd_volfile_path, volname, voltype):
     with open(info_file_path) as info_file:
         data = json.load(info_file)
 
-    content = generate_shd_volfile(data)
-    with open(shd_volfile_path, "w") as shd_volfile:
-        shd_volfile.write(content)
+    generate_shd_volfile(data, shd_volfile_path)
 
 
 def start_args():
@@ -34,10 +30,9 @@ def start_args():
     Start the Gluster Self-Heal Process
     """
     volname = os.environ["VOLUME"]
-    voltype = os.environ["VOLUME_TYPE"]
 
     shd_volfile_path = os.path.join(VOLFILES_DIR, "glustershd.vol")
-    create_shd_volfile(shd_volfile_path, volname, voltype)
+    create_shd_volfile(shd_volfile_path, volname)
 
     return Proc(
         "shd",

--- a/server/shd.py
+++ b/server/shd.py
@@ -1,5 +1,5 @@
 """
-Starts Gluster Brick(fsd) process
+Starts Gluster Brick Self Heal Daemon(shd) process
 """
 import json
 import os
@@ -7,55 +7,26 @@ import os
 from jinja2 import Template
 from kadalulib import Proc
 
+from serverutils import generate_shd_volfile
+
 VOLFILES_DIR = "/kadalu/volfiles"
-TEMPLATES_DIR = "/kadalu/templates"
 VOLINFO_DIR = "/var/lib/gluster"
 
 
-def generate_shd_volfile(client_volfile, volname, voltype):
-    """Generate Client Volfile for Glusterfs Volume"""
+def create_shd_volfile(shd_volfile_path, volname, voltype):
+    """
+    Generate Self Heal Daemon(SHD) Volfile for Glusterfs
+    Volume of type Replica2.
+    """
+
     info_file_path = os.path.join(VOLINFO_DIR, "%s.info" % volname)
     data = {}
     with open(info_file_path) as info_file:
         data = json.load(info_file)
 
-    # Tricky to get this right, but this solves all the elements of distribute in code :-)
-    data['dht_subvol'] = []
-    decommissioned = []
-    if data["type"] == "Replica1":
-        for brick in data["bricks"]:
-            brick_name = "%s-client-%d" % (data["volname"], brick["brick_index"])
-            data["dht_subvol"].append(brick_name)
-            if brick.get("decommissioned", "") != "":
-                decommissioned.append(brick_name)
-    else:
-        count = 3
-        if data["type"] == "Replica2":
-            count = 2
-
-        if data["type"] == "Disperse":
-            count = data["disperse"]["data"] + data["disperse"]["redundancy"]
-            data["disperse_redundancy"] = data["disperse"]["redundancy"]
-
-        data["subvol_bricks_count"] = count
-        for i in range(0, int(len(data["bricks"]) / count)):
-            brick_name = "%s-%s-%d" % (
-                data["volname"],
-                "disperse" if data["type"] == "Disperse" else "replica",
-                i
-            )
-            data["dht_subvol"].append(brick_name)
-            if data["bricks"][(i * count)].get("decommissioned", "") != "":
-                decommissioned.append(brick_name)
-
-    data['decommissioned'] = ",".join(decommissioned)
-    template_file_path = os.path.join(TEMPLATES_DIR,
-                                      "%s.shd.vol.j2" % voltype)
-    content = ""
-    with open(template_file_path) as template_file:
-        content = template_file.read()
-
-    Template(content).stream(**data).dump(client_volfile)
+    content = generate_shd_volfile(data)
+    with open(shd_volfile_path, "w") as shd_volfile:
+        shd_volfile.write(content)
 
 
 def start_args():
@@ -65,8 +36,8 @@ def start_args():
     volname = os.environ["VOLUME"]
     voltype = os.environ["VOLUME_TYPE"]
 
-    volfile_path = os.path.join(VOLFILES_DIR, "glustershd.vol")
-    generate_shd_volfile(volfile_path, volname, voltype)
+    shd_volfile_path = os.path.join(VOLFILES_DIR, "glustershd.vol")
+    create_shd_volfile(shd_volfile_path, volname, voltype)
 
     return Proc(
         "shd",
@@ -80,6 +51,6 @@ def start_args():
             "--xlator-option",
             "*replicate*.node-uuid=%s" % os.environ["NODEID"],
             "--fs-display-name", "kadalu:%s" % volname,
-            "-f", volfile_path
+            "-f", shd_volfile_path
         ]
     )


### PR DESCRIPTION
Updates: #959

**What this PR does / why we need it**:

- This PR makes changes to replace use of jinja templates for volfile generation to Kadalu Volgen Library.
Creates storage_unit/brick, Self Heal Daemon(shd) & client volfiles.

**Which issue(s) this PR fixes**:
Fixes #959 

**Checklist**
- [x] Documentation added - Will add after all components are handled with volfile_server & kadalu_volgen
- [x] Tests updated - Existing tests are enough for this PR.
- [x] Add an entry in the `CHANGELOG.md` about the changes.
