### PR TITLE
csi: Use volfile server for fetching client-volfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Server: Use Kadalu Volgen library for volfile generation
-- CSI: Fetch volfiles from brick/storage_unit process in server using --volfile-server
+- CSI: Fetch volfiles from brick processes in server using --volfile-server &
+  remove storage options from mount flow.
 
 ## [0.9.0] - 2022-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Server: Use Kadalu Volgen library for volfile generation
+- CSI: Fetch volfiles from brick/storage_unit process in server using --volfile-server
 
 ## [0.9.0] - 2022-11-21
 

--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -53,11 +53,6 @@ COPY csi/watch-logrotate.sh    /kadalu/
 
 COPY extras/kadalu-logrotate.conf     /kadalu/logrotate.conf
 
-COPY templates/Replica1.client.vol.j2 /kadalu/templates/
-COPY templates/Replica2.client.vol.j2 /kadalu/templates/
-COPY templates/Replica3.client.vol.j2 /kadalu/templates/
-COPY templates/Disperse.client.vol.j2 /kadalu/templates/
-
 RUN chmod +x /kadalu/startup.sh
 RUN chmod +x /kadalu/heal-info.sh
 

--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -131,8 +131,6 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
         pvtype = PV_TYPE_SUBVOL
         is_block = False
 
-        storage_options = request.parameters.get("storage_options", "")
-
         # Mounted BlockVolume is requested via Storage Class.
         # GlusterFS File Volume may not be useful for some workloads
         # they can request for the Virtual Block formated and mounted
@@ -399,8 +397,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
                     "pvtype": pvtype,
                     "path": vol.volpath,
                     "fstype": "xfs",
-                    "single_pv_per_pool": f"{single_pv_per_pool}",
-                    "storage_options": storage_options
+                    "single_pv_per_pool": f"{single_pv_per_pool}"
                 }
             })
 

--- a/csi/main.py
+++ b/csi/main.py
@@ -3,7 +3,6 @@ Starting point of CSI driver GRP server
 """
 import logging
 import os
-import signal
 import time
 from concurrent import futures
 
@@ -14,7 +13,7 @@ from identityserver import IdentityServer
 from kadalulib import CommandException, logf, logging_setup
 from nodeserver import NodeServer
 from volumeutils import (HOSTVOL_MOUNTDIR, get_pv_hosting_volumes,
-                         mount_glusterfs, reload_glusterfs)
+                         mount_glusterfs)
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
@@ -42,18 +41,6 @@ def mount_storage():
     return
 
 
-def reconfigure_mounts(_signum, _frame):
-    """
-    Reconfigure the mounts by regenerating the volfiles.
-    """
-    host_volumes = get_pv_hosting_volumes({})
-    for volume in host_volumes:
-        if volume["type"] == "External":
-            # Need to skip remount external
-            continue
-        if reload_glusterfs(volume):
-            logging.info(logf("Volume reloaded successfully", volume=volume))
-
 def main():
     """
     Register Controller Server, Node server and Identity Server and start
@@ -63,8 +50,6 @@ def main():
 
     # If Provisioner pod reboots, mount volumes if they exist before reboot
     mount_storage()
-
-    signal.signal(signal.SIGHUP, reconfigure_mounts)
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     csi_pb2_grpc.add_ControllerServicer_to_server(ControllerServer(), server)

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -9,7 +9,7 @@ import csi_pb2
 import csi_pb2_grpc
 import grpc
 from kadalulib import logf
-from volumeutils import mount_volume, unmount_volume
+from volumeutils import mount_glusterfs, mount_volume, unmount_volume
 
 HOSTVOL_MOUNTDIR = "/mnt"
 GLUSTERFS_CMD = "/opt/sbin/glusterfs"
@@ -84,6 +84,8 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
             'g_options': options,
             'type': voltype,
         }
+
+        mount_glusterfs(volume, mntdir, True)
 
         if voltype == "External":
             logging.debug(logf(

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -9,7 +9,7 @@ import csi_pb2
 import csi_pb2_grpc
 import grpc
 from kadalulib import logf
-from volumeutils import mount_glusterfs, mount_volume, unmount_volume
+from volumeutils import mount_volume, unmount_volume
 
 HOSTVOL_MOUNTDIR = "/mnt"
 GLUSTERFS_CMD = "/opt/sbin/glusterfs"
@@ -63,8 +63,6 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
         gvolname = request.volume_context.get("gvolname", None)
         options = request.volume_context.get("options", None)
 
-        # Storage volfile options
-        storage_options = request.volume_context.get("storage_options", "")
         mntdir = os.path.join(HOSTVOL_MOUNTDIR, hostvol)
 
         pvpath_full = os.path.join(mntdir, pvpath)
@@ -76,8 +74,7 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
             hostvol=hostvol,
             pvpath=pvpath,
             pvtype=pvtype,
-            pvpath_full=pvpath_full,
-            storage_options=storage_options
+            pvpath_full=pvpath_full
         ))
 
         volume = {
@@ -88,21 +85,13 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
             'type': voltype,
         }
 
-        mountpoint = mount_glusterfs(volume, mntdir, storage_options, True)
-
         if voltype == "External":
             logging.debug(logf(
                 "Mounted Volume for PV",
                 volume=volume,
-                mntdir=mntdir,
-                storage_options=storage_options
+                mntdir=mntdir
             ))
             # return csi_pb2.NodePublishVolumeResponse()
-
-        # When 'storage_options' is configured mountpoint & volfile path change,
-        # Update pvpath_full accordingly.
-        if storage_options != "":
-            pvpath_full = os.path.join(mountpoint, pvpath)
 
         logging.debug(logf(
             "Mounted Hosting Volume",

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -17,7 +17,7 @@ from kadalulib import (PV_TYPE_RAWBLOCK, PV_TYPE_SUBVOL, PV_TYPE_VIRTBLOCK,
                        get_volname_hash, get_volume_path,
                        is_gluster_mount_proc_running, logf, makedirs,
                        reachable_host, retry_errors, get_single_pv_per_pool,
-                       is_host_reachable)
+                       is_server_pod_reachable)
 
 GLUSTERFS_CMD = "/opt/sbin/glusterfs"
 MOUNT_CMD = "/bin/mount"
@@ -926,11 +926,11 @@ def mount_glusterfs(volume, mountpoint, is_client=False):
     for brick in data["bricks"]:
         hosts.append(brick["node"])
 
-    if not is_host_reachable(hosts, 24007, 100):
+    if not is_server_pod_reachable(hosts, 24007, 20):
         logging.error(logf(
-            "None of the hosts are reachable"
+            "None of the server pods are reachable"
         ))
-        raise CommandException
+        return mountpoint
 
     if volume['type'] == 'External':
         return handle_external_volume(volume, mountpoint, is_client, volume['g_host'])

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -79,9 +79,11 @@ def is_gluster_mount_proc_running(volname, mountpoint):
         return proc.returncode == 0
 
 
-def is_host_reachable(hosts, port):
-    """Check if glusterd is reachable in the given node"""
-    timeout = 5
+def is_host_reachable(hosts, port=22, timeout=5):
+    """
+    For external volume: Check if glusterd is reachable in the given node at port 22
+    For native volume: Check if glusterfsd is reachable in the given node at port 24007
+    """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(timeout)
     for host in hosts:

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -79,11 +79,39 @@ def is_gluster_mount_proc_running(volname, mountpoint):
         return proc.returncode == 0
 
 
-def is_host_reachable(hosts, port=22, timeout=5):
+def is_server_pod_reachable(hosts, port=24007, timeout=20):
     """
-    For external volume: Check if glusterd is reachable in the given node at port 22
-    For native volume: Check if glusterfsd is reachable in the given node at port 24007
+    Return True if atleast one of server pods(internal hosts),
+    are reachable at port 24007.
+    Retries every 30 seconds if the server pod is not reachable.
+    Returns False server pods are not reachable even after the timeout.
     """
+
+    socket.setdefaulttimeout(timeout)
+
+    for host in hosts:
+        retry_count = 0
+        while retry_count < 2:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.connect((host, port))
+                sock.close()
+                return True
+            except socket.error:
+                logging.info(logf(
+                    "Waiting for the server pod to come up...",
+                    server_pod=host,
+                    retry_count=retry_count+1
+                ))
+                time.sleep(30)
+                retry_count += 1
+    return False
+
+
+def is_host_reachable(hosts, port):
+    """Check if glusterd is reachable in the given node"""
+
+    timeout = 5
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(timeout)
     for host in hosts:

--- a/server/serverutils.py
+++ b/server/serverutils.py
@@ -41,11 +41,16 @@ def generate_client_volgen_data(data):
 
     for dist_grp_idx, dist_grp in enumerate(client_data["distribute_groups"]):
         if "Replica" in data["type"]:
-            dist_grp["type"] = "replica"
+            dist_grp["type"] = "replicate"
         else:
             dist_grp["type"] = "disperse"
 
-        dist_grp["replica_count"] = replica_count
+        if replica_count:
+            dist_grp["replica_count"] = replica_count
+        if dist_grp["type"] == "disperse":
+            dist_grp["disperse_count"] = data["disperse"].get("data", 0)
+            dist_grp["redundancy_count"] = data["disperse"].get("redundancy", 0)
+
         dist_grp["storage_units"] = [{} for _ in range(storage_unit_count)]
 
         for storage_unit_idx, storage_unit in enumerate(dist_grp["storage_units"]):


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:

- This PR makes changes in CSI necessary to make use of volfile-server feature of brick processes,
where regeneration of client volfiles are not required, instead can fetch from any one of brick_processes.
Can add multiple brick_process to be notified as backup volfile servers. Which serves the volfiles stored in 
`/var/lib/kadalu/volfiles` inside server pods.
Can be accessed using `--volfile-server` option.

- Remove storage_options from mount flow. Later in upcoming PRs create a framework for storage_options to be configured at operator component.

**Which issue(s) this PR fixes**:
Updates: #959 

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added : No user related information are expected from this PR.
- [x] Tests updated : Existing tests are enough for this PR.
- [x] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Shree Vatsa N [vatsa@kadalu.tech](mailto:vatsa@kadalu.tech)
