### PR TITLE
csi: Fix external volume bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSI: Fetch volfiles from brick processes in server using --volfile-server &
   remove storage options from mount flow.
 - Server: Disbale default client volfile options
+- CSI[BUG]: Use bricks data only for volume type=native
 
 ## [0.9.0] - 2022-11-21
 

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -920,9 +920,12 @@ def mount_glusterfs(volume, mountpoint, is_client=False):
     data = {}
     hosts = []
     volname = volume["name"]
+
+    if volume['type'] == 'External':
+        return handle_external_volume(volume, mountpoint, is_client, volume['g_host'])
+
     with open(os.path.join(VOLINFO_DIR, "%s.info" % volname)) as info_file:
         data = json.load(info_file)
-
     for brick in data["bricks"]:
         hosts.append(brick["node"])
 
@@ -936,9 +939,6 @@ def mount_glusterfs(volume, mountpoint, is_client=False):
             "None of the server pods are reachable",
             volume=volume
         ))
-
-    if volume['type'] == 'External':
-        return handle_external_volume(volume, mountpoint, is_client, volume['g_host'])
 
     # Ignore if already glusterfs process running for that volume
     if is_gluster_mount_proc_running(volname, mountpoint):


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
Use bricks data only for native volume type.

**Which issue(s) this PR fixes**:
```[2023-03-23 02:36:33,061] ERROR [_server - 454:_call_behavior] - Exception calling application: 'bricks'
Traceback (most recent call last):
  File "/kadalu/lib/python3.10/site-packages/grpc/_server.py", line 444, in _call_behavior
    response_or_iterator = behavior(argument, context)
  File "/kadalu/controllerserver.py", line 120, in CreateVolume
    volume = search_volume(request.name)
  File "/kadalu/volumeutils.py", line 780, in search_volume
    mount_glusterfs(volume, mntdir)
  File "/kadalu/volumeutils.py", line 926, in mount_glusterfs
    for brick in data["bricks"]:
KeyError: 'bricks'
```

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>
