### PR TITLE
server,cli,operator: Add feature for volume type Arbiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remove storage options from mount flow.
 - Server: Disbale default client volfile options
 - CLI: Move healinfo to server pods, Trigger client-heal from csi pod.
+- Server, CLI, Operator: Add feature for volume type Arbiter
 
 ## [0.9.0] - 2022-11-21
 

--- a/cli/kubectl_kadalu/storage_add.py
+++ b/cli/kubectl_kadalu/storage_add.py
@@ -33,7 +33,7 @@ def set_args(name, subparsers):
         default=None)
     arg("--type",
         help="Storage Type",
-        choices=["Replica1", "Replica3", "External", "Replica2", "Disperse"],
+        choices=["Replica1", "Replica3", "External", "Replica2", "Disperse", "Arbiter"],
         default=None)
     arg("--volume-id",
         help="Volume ID of previously created volume",

--- a/cli/kubectl_kadalu/storage_add_parser.py
+++ b/cli/kubectl_kadalu/storage_add_parser.py
@@ -207,6 +207,10 @@ def distribute_group(storage_units, current_keyword):
             len(storage_units["replica"]),
             len(storage_units["mirror"])
         )
+    elif len(storage_units["arbiter"]) == 3:
+        dist_group.storage_units = storage_units["arbiter"]
+        dist_group.replica_count = 3
+        dist_group.arbiter_count = 1
     elif len(storage_units["disperse"]) > 0 or \
          len(storage_units["disperse-data"]) > 0:
         dist_group.storage_units = storage_units["disperse"] + \

--- a/cli/kubectl_kadalu/storage_add_parser.py
+++ b/cli/kubectl_kadalu/storage_add_parser.py
@@ -311,8 +311,12 @@ def validate(req):
     Validate the Volume create request after parsing
     """
     for dist_grp in req.distribute_groups:
+        replica_arbiter_dist_grp_size = dist_grp.replica_count
+        if dist_grp.arbiter_count > 0 and dist_grp.replica_count == 2:
+            replica_arbiter_dist_grp_size += 1
+
         if dist_grp.replica_count > 0 and \
-           len(dist_grp.storage_units) != dist_grp.replica_count:
+           len(dist_grp.storage_units) != replica_arbiter_dist_grp_size:
             raise InvalidVolumeCreateRequest(
                 "Number of Storage units not matching "
                 f"{dist_grp.replica_keyword} count"
@@ -327,6 +331,9 @@ def validate(req):
 def volume_type(req):
     """Find Volume Type based on the first distribute Group"""
     dist_grp_1 = req.distribute_groups[0]
+    if dist_grp_1.arbiter_count > 0:
+        return "Arbiter"
+
     if dist_grp_1.replica_count == 2:
         return "Replica2"
 

--- a/server/glusterfsd.py
+++ b/server/glusterfsd.py
@@ -63,26 +63,18 @@ def set_volume_id_xattr(brick_path, volume_id):
         sys.exit(1)
 
 
-def create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_path):
+def create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_path, data):
     """
     Create Brick/Storage Unit Volfile based on Volinfo stored in Config map
     For now, Generated Volfile is used in configmap
     """
 
     storage_unit = {}
-    info_file_path = os.path.join(VOLINFO_DIR, "%s.info" % volname)
-    data = {}
-    with open(info_file_path) as info_file:
-        data = json.load(info_file)
 
-    if data["type"] == "Arbiter":
-        bricks = data.get("bricks", None)
-        if len(bricks) > 2 and len(bricks) % 3 == 0:
-            # Mark every third brick starting from index 2 (0 based),
-            # If it matches the current brick_index as type 'arbiter'.
-            for index in range(2, len(bricks), 3):
-                if int(bricks[index].get("brick_index")) == int(os.environ.get("BRICK_INDEX")):
-                    storage_unit["type"] = "arbiter"
+    # Set every third brick/storage_unit as arbiter brick.
+    # Arbiter brick will hold only file & directory structure but not the content.
+    if data["type"] == "Arbiter" and (int(os.environ.get("BRICK_INDEX")) + 1) % 3 == 0:
+        storage_unit["type"] = "arbiter"
 
     storage_unit["path"] = brick_path
     storage_unit["port"] = 24007
@@ -93,19 +85,13 @@ def create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_pa
     generate_brick_volfile(storage_unit, storage_unit_volfile_path)
 
 
-def create_client_volfile(client_volfile_path, volname):
+def create_client_volfile(client_volfile_path, data):
     """
     Create client volfile based on Volinfo stored in Config map using
     Kadalu Volgen library.
     """
 
-    info_file_path = os.path.join(VOLINFO_DIR, "%s.info" % volname)
-    data = {}
-    with open(info_file_path) as info_file:
-        data = json.load(info_file)
-
     generate_client_volfile(data, client_volfile_path)
-
 
 
 def create_and_mount_brick(brick_device, brick_path, brickfs):
@@ -224,8 +210,14 @@ def start_args():
     volfile_id = "%s.%s.%s" % (volname, nodename, brick_path_name)
     storage_unit_volfile_path = os.path.join(VOLFILES_DIR, "%s.vol" % volfile_id)
     client_volfile_path = os.path.join(VOLFILES_DIR, "%s.vol" % volname)
-    create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_path)
-    create_client_volfile(client_volfile_path, volname)
+
+    info_file_path = os.path.join(VOLINFO_DIR, "%s.info" % volname)
+    data = {}
+    with open(info_file_path) as info_file:
+        data = json.load(info_file)
+
+    create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_path, data)
+    create_client_volfile(client_volfile_path, data)
 
     # UID is stored at the time of installation in configmap.
     uid = None

--- a/server/glusterfsd.py
+++ b/server/glusterfsd.py
@@ -70,6 +70,20 @@ def create_brick_volfile(storage_unit_volfile_path, volname, volume_id, brick_pa
     """
 
     storage_unit = {}
+    info_file_path = os.path.join(VOLINFO_DIR, "%s.info" % volname)
+    data = {}
+    with open(info_file_path) as info_file:
+        data = json.load(info_file)
+
+    if data["type"] == "Arbiter":
+        bricks = data.get("bricks", None)
+        if len(bricks) > 2 and len(bricks) % 3 == 0:
+            # Mark every third brick starting from index 2 (0 based),
+            # If it matches the current brick_index as type 'arbiter'.
+            for index in range(2, len(bricks), 3):
+                if int(bricks[index].get("brick_index")) == int(os.environ.get("BRICK_INDEX")):
+                    storage_unit["type"] = "arbiter"
+
     storage_unit["path"] = brick_path
     storage_unit["port"] = 24007
     storage_unit["volume"] = {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
This PR adds feature to support volume type `Arbiter`. 
Makes necessary CLI changes to add alternate syntax to create Arbiter volumes, adds validations in kadalu-operator for defualt syntax type.
In server pods, mark every third brick/storage-unit as type=arbiter. Which then will be used by kadalu/volgen library to create server brick process inculding `features/arbiter` in the server graph.
Adds `arbiter-count` to client and shd volfile data before passing to kadalu-volgen.

**Which issue(s) this PR fixes**:
Fixes #977 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added: Will send a separate PR for doc with cli usage.
- [ ] Tests updated
- [x] Add an entry in the `CHANGELOG.md` about the changes.

Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>
