### PR TITLE
cli,doc: Add new sub-commands 'option-set' & 'option-reset'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server: Disbale default client volfile options
 - CLI: Move healinfo to server pods, Trigger client-heal from csi pod.
 - Server, CLI, Operator: Add feature for volume type Arbiter
+- Operator, Server, CLI: Add feature of Storage Pool Options
 
 ## [0.9.0] - 2022-11-21
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -160,7 +160,27 @@ $ kubectl kadalu healinfo --trigger-full-heal --name=storage-pool-1
 > Note:
 > Alternatively can run below as shell scrips by exec-ing into server-pods, without install kubeclt-kadalu.
 
+### Configuring Storage Pool Options
 
+To add/set Storage Pool Options, 'option-set' subcommand can be used. It expects name of Storage Pool to be configured and Option key(s) and value(s).
+
+```
+$ kubectl kadalu option-set storage-pool1 \
+    performance.quick-read off performance.write-behind on
+```
+
+To remove/reset Storage Pool Options, 'option-reset' subcommand can be used. It expects name of Storage Pool to be configured and Option key(s) to be removed.
+
+```
+$ kubectl kadalu option-reset storage-pool1 \
+    performance.quick-read performance.write-behind
+```
+
+Additionally all of configured options for a Storage Pool can be removed with '--all' flag.
+
+```
+$ kubectl kadalu option-reset storage-pool1 --all
+```
 
 ## Contributing
 

--- a/cli/kubectl_kadalu/__main__.py
+++ b/cli/kubectl_kadalu/__main__.py
@@ -20,7 +20,9 @@ SUPPORTED_ARGS = [
     "storage-remove",
     "remove-archived-pv",
     "logs",
-    "healinfo"
+    "healinfo",
+    "option-set",
+    "option-reset"
 ]
 
 def get_args():

--- a/cli/kubectl_kadalu/option_reset.py
+++ b/cli/kubectl_kadalu/option_reset.py
@@ -98,8 +98,6 @@ def run(args):
         utils.kubectl_cmd_help(args.kubectl_cmd)
         sys.exit(1)
 
-    print("from data", data["spec"].get("options", []))
-
     if data["spec"].get("options", []):
         options = data["spec"]["options"]
         for option in options:
@@ -109,8 +107,6 @@ def run(args):
 
     if existing_options is None:
         print("No options present in Storage Pool to reset.")
-
-    print("existing_options", existing_options)
 
     updated_options = existing_options.copy()
 
@@ -139,14 +135,6 @@ def run(args):
             for key, value in updated_options.items():
                 print("Key: %s :: Value: %s" %(key, value))
 
-
-    # # given_options = given_data.get("options", {})
-    # print("given_options", given_options)
-
-    # existing_options.update(given_options)
-
-    # print(existing_options)
-
     # Save back into CRD in array of objects format.
     # Which will be processed while deploying configmaps in operator.
     if updated_options is None:
@@ -155,10 +143,7 @@ def run(args):
         for key,value in updated_options.items():
             options.append({"key": key, "value": value})
 
-    print(options)
-
     data["spec"]["options"] = options
-    print("to data", data)
 
     if args.dry_run:
         return
@@ -186,6 +171,6 @@ def run(args):
         print()
     except FileNotFoundError:
         utils.kubectl_cmd_help(args.kubectl_cmd)
-    # finally:
-    #     if os.path.exists(temp_file_path):
-    #         os.remove(temp_file_path)
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)

--- a/cli/kubectl_kadalu/option_reset.py
+++ b/cli/kubectl_kadalu/option_reset.py
@@ -117,9 +117,7 @@ def run(args):
         print("All Existing Storage Pool Options below will be cleared")
         for key, value in existing_options.items():
             print("Key: %s :: Value: %s" %(key, value))
-
         updated_options = updated_options.clear()
-        print("updated options after clear()", updated_options)
 
     # Remove user specified options
     else:
@@ -156,7 +154,6 @@ def run(args):
     with open(temp_file_path, mode="w", encoding="utf-8") as temp_file:
         # Write the data to the file in JSON format
         json.dump(data, temp_file)
-        print(temp_file_path)
 
     cmd = utils.kubectl_cmd(args) + [
         "apply", "-f", temp_file_path]

--- a/cli/kubectl_kadalu/option_reset.py
+++ b/cli/kubectl_kadalu/option_reset.py
@@ -1,0 +1,191 @@
+"""
+'option-reset' sub command
+"""
+
+# noqa # pylint: disable=duplicate-code
+# noqa # pylint: disable=too-many-branches
+
+#To prevent Py2 to interpreting print(val) as a tuple.
+from __future__ import print_function
+
+import json
+import os
+import sys
+import tempfile
+import argparse
+import utils
+import copy
+
+def set_args(name, subparsers):
+    """ add arguments, and their options """
+    # TODO: Sub group arguments to relax validation manually
+    # https://docs.python.org/3/library/argparse.html#argument-groups
+    parser = subparsers.add_parser(name, formatter_class=argparse.RawTextHelpFormatter)
+    arg = parser.add_argument
+
+    arg("name", help="Storage Name")
+    arg("options",
+        help=('Reset or Remove Storage pool options in "<xlator>" format.\n'
+              'Example: option-reset <POOL NAME> performance.write-behind\n'
+              'Example: option-reset <POOL NAME> performance.quick-read performance.open-behind on'),
+        nargs="*",
+        action="store")
+    arg("--all",
+        help=('Reset or Remove all Storage pool options.\n'),
+        action="store_true", default=False)
+
+    utils.add_global_flags(parser)
+
+
+# pylint: disable=too-many-statements
+def validate(args):
+    """ validate arguments """
+
+    # Error out when options is not specified and --all flag is not set
+    if len(args.options) < 1 and not args.all:
+        print(
+            "Invalid storage pool option-reset details. Please specify options "
+            'details in the format "<xlator>" or "<xlator1> <xlator2> <xlator3> ..."',
+            file=sys.stderr)
+        sys.exit(1)
+
+    # Error out when both options and --all used in conjunction.
+    if args.all and len(args.options):
+        print(
+            "Invalid storage pool option-reset details. Please either specify options "
+            'to be removed or use --all to remove all existing options',
+            file=sys.stderr)
+        sys.exit(1)
+
+
+def user_confirmation(args):
+    if not args.script_mode:
+        answer = ""
+        valid_answers = ["yes", "no", "n", "y"]
+        while answer not in valid_answers:
+            answer = input("Is this correct?(Yes/No): ")
+            answer = answer.strip().lower()
+
+        if answer in ["n", "no"]:
+            return False
+
+    return True
+
+
+def run(args):
+    """ Adds the subcommand arguments back to main CLI tool """
+
+    data = {}
+    updated_options = {}
+    existing_options = {}
+    options = []
+
+    cmd = utils.kubectl_cmd(args) + [
+            "get", "kadalustorages.kadalu-operator.storage",
+            args.name, "-ojson"]
+
+    try:
+        resp = utils.execute(cmd)
+        data = json.loads(resp.stdout)
+    except utils.CommandError as err:
+        print("Failed to get CRD of "
+                "storage \"%s\"" % args.name,
+                file=sys.stderr)
+        print(err, file=sys.stderr)
+        print()
+        sys.exit(1)
+    except FileNotFoundError:
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+        sys.exit(1)
+
+    print("from data", data["spec"].get("options", []))
+
+    if data["spec"].get("options", []):
+        options = data["spec"]["options"]
+        for option in options:
+            existing_options.update({
+                option.get("key"): option.get("value")
+            })
+
+    if existing_options is None:
+        print("No options present in Storage Pool to reset.")
+
+    print("existing_options", existing_options)
+
+    updated_options = existing_options.copy()
+
+    # Remove all options
+    if args.all:
+        print("All Existing Storage Pool Options below will be cleared")
+        for key, value in existing_options.items():
+            print("Key: %s :: Value: %s" %(key, value))
+
+        updated_options = updated_options.clear()
+        print("updated options after clear()", updated_options)
+
+    # Remove user specified options
+    else:
+        for option in args.options:
+            if option in updated_options:
+                del updated_options[option]
+        print("Storage Options before updation")
+        for key,value in existing_options.items():
+            print("Key: %s :: Value: %s" %(key, value))
+        print()
+        print("Storage Options after updation")
+        if not updated_options:
+            print("No Storage Options left after updation!")
+        else:
+            for key, value in updated_options.items():
+                print("Key: %s :: Value: %s" %(key, value))
+
+
+    # # given_options = given_data.get("options", {})
+    # print("given_options", given_options)
+
+    # existing_options.update(given_options)
+
+    # print(existing_options)
+
+    # Save back into CRD in array of objects format.
+    # Which will be processed while deploying configmaps in operator.
+    if updated_options is None:
+        options = []
+    else:
+        for key,value in updated_options.items():
+            options.append({"key": key, "value": value})
+
+    print(options)
+
+    data["spec"]["options"] = options
+    print("to data", data)
+
+    if args.dry_run:
+        return
+
+    if not user_confirmation(args):
+        return
+
+    # Create a temporary file named "<pool_name>.json"
+    temp_file_path = tempfile.gettempdir() + "/%s.json" % (args.name)
+    with open(temp_file_path, mode="w") as temp_file:
+        # Write the data to the file in JSON format
+        json.dump(data, temp_file)
+        print(temp_file_path)
+
+    cmd = utils.kubectl_cmd(args) + [
+            "apply", "-f", temp_file_path]
+
+    try:
+        resp = utils.execute(cmd)
+    except utils.CommandError as err:
+        print("Failed to apply CRD for "
+                "storage \"%s\"" % args.name,
+                file=sys.stderr)
+        print(err, file=sys.stderr)
+        print()
+    except FileNotFoundError:
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+    # finally:
+    #     if os.path.exists(temp_file_path):
+    #         os.remove(temp_file_path)

--- a/cli/kubectl_kadalu/option_set.py
+++ b/cli/kubectl_kadalu/option_set.py
@@ -36,8 +36,6 @@ def set_args(name, subparsers):
 def validate(args):
     """ validate arguments """
 
-    print(len(args.options))
-
     if len(args.options) < 2 or len(args.options) % 2 != 0:
         print(
             "Invalid storage pool option-set details. Please specify options "
@@ -73,16 +71,12 @@ def run(args):
         utils.kubectl_cmd_help(args.kubectl_cmd)
         sys.exit(1)
 
-    print("from data", data["spec"].get("options", []))
-
     if data["spec"].get("options", []):
         options = data["spec"]["options"]
         for option in options:
             existing_options.update({
                 option.get("key"): option.get("value")
             })
-
-    print("existing_options", existing_options)
 
     updated_options = existing_options.copy()
 
@@ -91,21 +85,14 @@ def run(args):
             args.options[index]: args.options[index + 1]
         })
 
-    print("given_options", given_options)
-
     updated_options.update(given_options)
-
-    print("updated_options", updated_options)
 
     # Save back into CRD in array of objects format.
     # Which will be processed while deploying configmaps in operator.
     for key,value in updated_options.items():
         options.append({"key": key, "value": value})
 
-    print(options)
-
     data["spec"]["options"] = options
-    print("to data", data)
 
     print("Storage Options before updation")
     if not existing_options:
@@ -151,6 +138,6 @@ def run(args):
         print()
     except FileNotFoundError:
         utils.kubectl_cmd_help(args.kubectl_cmd)
-    # finally:
-    #     if os.path.exists(temp_file_path):
-    #         os.remove(temp_file_path)
+    finally:
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)

--- a/cli/kubectl_kadalu/option_set.py
+++ b/cli/kubectl_kadalu/option_set.py
@@ -2,9 +2,6 @@
 'option-set' sub command
 """
 
-# noqa # pylint: disable=duplicate-code
-# noqa # pylint: disable=too-many-branches
-
 #To prevent Py2 to interpreting print(val) as a tuple.
 from __future__ import print_function
 
@@ -79,9 +76,7 @@ def run(args):
             })
 
     for index in range(0, len(args.options), 2):
-        given_options.update({
-            args.options[index]: args.options[index + 1]
-        })
+        given_options[args.options[index]] = args.options[index + 1]
 
     existing_options.update(given_options)
 
@@ -106,6 +101,7 @@ def run(args):
 
     try:
         resp = utils.execute(cmd)
+        print(f"Storage Pool {args.name} storage-options configured.")
     except utils.CommandError as err:
         print("Failed to apply CRD for "
               "storage \"%s\"" % args.name,

--- a/cli/kubectl_kadalu/option_set.py
+++ b/cli/kubectl_kadalu/option_set.py
@@ -100,7 +100,6 @@ def run(args):
     with open(temp_file_path, mode="w", encoding="utf-8") as temp_file:
         # Write the data to the file in JSON format
         json.dump(data, temp_file)
-        print(temp_file_path)
 
     cmd = utils.kubectl_cmd(args) + [
         "apply", "-f", temp_file_path]

--- a/cli/kubectl_kadalu/option_set.py
+++ b/cli/kubectl_kadalu/option_set.py
@@ -1,0 +1,156 @@
+"""
+'option-set' sub command
+"""
+
+# noqa # pylint: disable=duplicate-code
+# noqa # pylint: disable=too-many-branches
+
+#To prevent Py2 to interpreting print(val) as a tuple.
+from __future__ import print_function
+
+import json
+import os
+import sys
+import tempfile
+import argparse
+import utils
+
+def set_args(name, subparsers):
+    """ add arguments, and their options """
+    # TODO: Sub group arguments to relax validation manually
+    # https://docs.python.org/3/library/argparse.html#argument-groups
+    parser = subparsers.add_parser(name, formatter_class=argparse.RawTextHelpFormatter)
+    arg = parser.add_argument
+
+    arg("name", help="Storage Name")
+    arg("options",
+        help=('Add or Set Storage pool options in "<xlator> <value>" format.\n'
+              'Example: option-set <POOL NAME> performance.write-behind on\n'
+              'Example: option-set <POOL NAME> performance.quick-read on performance.open-behind on'),
+        nargs="+",
+        action="store")
+    utils.add_global_flags(parser)
+
+
+# pylint: disable=too-many-statements
+def validate(args):
+    """ validate arguments """
+
+    print(len(args.options))
+
+    if len(args.options) < 2 or len(args.options) % 2 != 0:
+        print(
+            "Invalid storage pool option-set details. Please specify options "
+            'details in the format "<xlator> <value>" or "<xlator1> <value1> <xlator2> <value2> ..."',
+            file=sys.stderr)
+        sys.exit(1)
+
+
+def run(args):
+    """ Adds the subcommand arguments back to main CLI tool """
+
+    data = {}
+    updated_options = {}
+    existing_options = {}
+    given_options = {}
+    options = []
+
+    cmd = utils.kubectl_cmd(args) + [
+            "get", "kadalustorages.kadalu-operator.storage",
+            args.name, "-ojson"]
+
+    try:
+        resp = utils.execute(cmd)
+        data = json.loads(resp.stdout)
+    except utils.CommandError as err:
+        print("Failed to get CRD of "
+                "storage \"%s\"" % args.name,
+                file=sys.stderr)
+        print(err, file=sys.stderr)
+        print()
+        sys.exit(1)
+    except FileNotFoundError:
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+        sys.exit(1)
+
+    print("from data", data["spec"].get("options", []))
+
+    if data["spec"].get("options", []):
+        options = data["spec"]["options"]
+        for option in options:
+            existing_options.update({
+                option.get("key"): option.get("value")
+            })
+
+    print("existing_options", existing_options)
+
+    updated_options = existing_options.copy()
+
+    for index in range(0, len(args.options), 2):
+        given_options.update({
+            args.options[index]: args.options[index + 1]
+        })
+
+    print("given_options", given_options)
+
+    updated_options.update(given_options)
+
+    print("updated_options", updated_options)
+
+    # Save back into CRD in array of objects format.
+    # Which will be processed while deploying configmaps in operator.
+    for key,value in updated_options.items():
+        options.append({"key": key, "value": value})
+
+    print(options)
+
+    data["spec"]["options"] = options
+    print("to data", data)
+
+    print("Storage Options before updation")
+    if not existing_options:
+        print("Storage Options not yet configured!")
+    else:
+        for key,value in existing_options.items():
+            print("Key: %s :: Value: %s" %(key, value))
+    print()
+    print("Storage Options after updation")
+    for key, value in updated_options.items():
+        print("Key: %s :: Value: %s" %(key, value))
+
+    if args.dry_run:
+        return
+
+    if not args.script_mode:
+        answer = ""
+        valid_answers = ["yes", "no", "n", "y"]
+        while answer not in valid_answers:
+            answer = input("Is this correct?(Yes/No): ")
+            answer = answer.strip().lower()
+
+        if answer in ["n", "no"]:
+            return
+
+    # Create a temporary file named "<pool_name>.json"
+    temp_file_path = tempfile.gettempdir() + "/%s.json" % (args.name)
+    with open(temp_file_path, mode="w") as temp_file:
+        # Write the data to the file in JSON format
+        json.dump(data, temp_file)
+        print(temp_file_path)
+
+    cmd = utils.kubectl_cmd(args) + [
+            "apply", "-f", temp_file_path]
+
+    try:
+        resp = utils.execute(cmd)
+    except utils.CommandError as err:
+        print("Failed to apply CRD for "
+                "storage \"%s\"" % args.name,
+                file=sys.stderr)
+        print(err, file=sys.stderr)
+        print()
+    except FileNotFoundError:
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+    # finally:
+    #     if os.path.exists(temp_file_path):
+    #         os.remove(temp_file_path)

--- a/cli/kubectl_kadalu/option_set.py
+++ b/cli/kubectl_kadalu/option_set.py
@@ -26,7 +26,8 @@ def set_args(name, subparsers):
     arg("options",
         help=('Add or Set Storage pool options in "<xlator> <value>" format.\n'
               'Example: option-set <POOL NAME> performance.write-behind on\n'
-              'Example: option-set <POOL NAME> performance.quick-read on performance.open-behind on'),
+              'Example: option-set <POOL NAME> performance.quick-read on '
+              'performance.open-behind on'),
         nargs="+",
         action="store")
     utils.add_global_flags(parser)
@@ -37,10 +38,10 @@ def validate(args):
     """ validate arguments """
 
     if len(args.options) < 2 or len(args.options) % 2 != 0:
-        print(
-            "Invalid storage pool option-set details. Please specify options "
-            'details in the format "<xlator> <value>" or "<xlator1> <value1> <xlator2> <value2> ..."',
-            file=sys.stderr)
+        print('Invalid storage pool option-set details. Please specify options '
+              'details in the format "<xlator> <value>" or '
+              '<xlator1> <value1> <xlator2> <value2> ...',
+              file=sys.stderr)
         sys.exit(1)
 
 
@@ -48,22 +49,21 @@ def run(args):
     """ Adds the subcommand arguments back to main CLI tool """
 
     data = {}
-    updated_options = {}
     existing_options = {}
     given_options = {}
     options = []
 
     cmd = utils.kubectl_cmd(args) + [
-            "get", "kadalustorages.kadalu-operator.storage",
-            args.name, "-ojson"]
+        "get", "kadalustorages.kadalu-operator.storage",
+        args.name, "-ojson"]
 
     try:
         resp = utils.execute(cmd)
         data = json.loads(resp.stdout)
     except utils.CommandError as err:
         print("Failed to get CRD of "
-                "storage \"%s\"" % args.name,
-                file=sys.stderr)
+              "storage \"%s\"" % args.name,
+              file=sys.stderr)
         print(err, file=sys.stderr)
         print()
         sys.exit(1)
@@ -72,68 +72,45 @@ def run(args):
         sys.exit(1)
 
     if data["spec"].get("options", []):
-        options = data["spec"]["options"]
-        for option in options:
+        e_options = data["spec"]["options"]
+        for option in e_options:
             existing_options.update({
                 option.get("key"): option.get("value")
             })
-
-    updated_options = existing_options.copy()
 
     for index in range(0, len(args.options), 2):
         given_options.update({
             args.options[index]: args.options[index + 1]
         })
 
-    updated_options.update(given_options)
+    existing_options.update(given_options)
 
     # Save back into CRD in array of objects format.
     # Which will be processed while deploying configmaps in operator.
-    for key,value in updated_options.items():
+    for key, value in existing_options.items():
         options.append({"key": key, "value": value})
 
     data["spec"]["options"] = options
 
-    print("Storage Options before updation")
-    if not existing_options:
-        print("Storage Options not yet configured!")
-    else:
-        for key,value in existing_options.items():
-            print("Key: %s :: Value: %s" %(key, value))
-    print()
-    print("Storage Options after updation")
-    for key, value in updated_options.items():
-        print("Key: %s :: Value: %s" %(key, value))
-
     if args.dry_run:
         return
 
-    if not args.script_mode:
-        answer = ""
-        valid_answers = ["yes", "no", "n", "y"]
-        while answer not in valid_answers:
-            answer = input("Is this correct?(Yes/No): ")
-            answer = answer.strip().lower()
-
-        if answer in ["n", "no"]:
-            return
-
     # Create a temporary file named "<pool_name>.json"
     temp_file_path = tempfile.gettempdir() + "/%s.json" % (args.name)
-    with open(temp_file_path, mode="w") as temp_file:
+    with open(temp_file_path, mode="w", encoding="utf-8") as temp_file:
         # Write the data to the file in JSON format
         json.dump(data, temp_file)
         print(temp_file_path)
 
     cmd = utils.kubectl_cmd(args) + [
-            "apply", "-f", temp_file_path]
+        "apply", "-f", temp_file_path]
 
     try:
         resp = utils.execute(cmd)
     except utils.CommandError as err:
         print("Failed to apply CRD for "
-                "storage \"%s\"" % args.name,
-                file=sys.stderr)
+              "storage \"%s\"" % args.name,
+              file=sys.stderr)
         print(err, file=sys.stderr)
         print()
     except FileNotFoundError:

--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -3,6 +3,7 @@
 """
 from __future__ import print_function
 import sys
+import json
 
 import utils
 
@@ -47,6 +48,40 @@ def human_readable_size(size):
     return "%d" % int(size)
 
 
+def get_options_from_crd(args, storage_name):
+    """ Fetch existing storage pool options from CRD """
+
+    data = {}
+    existing_options = {}
+
+    cmd = utils.kubectl_cmd(args) + [
+        "get", "kadalustorages.kadalu-operator.storage",
+        storage_name, "-ojson"]
+
+    try:
+        resp = utils.execute(cmd)
+        data = json.loads(resp.stdout)
+    except utils.CommandError as err:
+        print("Failed to get CRD of "
+                "storage \"%s\"" % args.name,
+                file=sys.stderr)
+        print(err, file=sys.stderr)
+        print()
+        sys.exit(1)
+    except FileNotFoundError:
+        utils.kubectl_cmd_help(args.kubectl_cmd)
+        sys.exit(1)
+
+    if data["spec"].get("options", []):
+        options = data["spec"]["options"]
+        for option in options:
+            existing_options.update({
+                option.get("key"): option.get("value")
+            })
+
+    return existing_options
+
+
 def detailed_output(storages, args):
     """Print the detailed output"""
     for storage in storages:
@@ -84,6 +119,13 @@ def detailed_output(storages, args):
                 print("  PVC: %s" % storage_unit.pvc)
 
             print()
+
+        options = get_options_from_crd(args, storage.storage_name)
+        if options:
+            print("Configured Storage Options: (%s)" % (len(options)))
+            for key,val in options.items():
+                print("%s : %s" % (key, val))
+
 
 
 def summary_output(storages, args):

--- a/cli/kubectl_kadalu/storage_list.py
+++ b/cli/kubectl_kadalu/storage_list.py
@@ -52,7 +52,6 @@ def get_options_from_crd(args, storage_name):
     """ Fetch existing storage pool options from CRD """
 
     data = {}
-    existing_options = {}
 
     cmd = utils.kubectl_cmd(args) + [
         "get", "kadalustorages.kadalu-operator.storage",
@@ -72,14 +71,7 @@ def get_options_from_crd(args, storage_name):
         utils.kubectl_cmd_help(args.kubectl_cmd)
         sys.exit(1)
 
-    if data["spec"].get("options", []):
-        options = data["spec"]["options"]
-        for option in options:
-            existing_options.update({
-                option.get("key"): option.get("value")
-            })
-
-    return existing_options
+    return data["spec"].get("options", [])
 
 
 def detailed_output(storages, args):
@@ -123,9 +115,8 @@ def detailed_output(storages, args):
         options = get_options_from_crd(args, storage.storage_name)
         if options:
             print("Configured Storage Options: (%s)" % (len(options)))
-            for key,val in options.items():
-                print("%s : %s" % (key, val))
-
+            for option in options:
+                print(f'{option.get("key")} : {option.get("value")}')
 
 
 def summary_output(storages, args):

--- a/doc/storage-config-options.adoc
+++ b/doc/storage-config-options.adoc
@@ -309,11 +309,20 @@ $ kubectl kadalu storage-add storage-pool1 \
 Storage Pool can be modified in their behaviour by configuring with Storage Pool Options available on Kadalu.
 Storage Pool Options can be configured either through storage-config file or using Kubectl Kadalu CLI.
 
-[TODO]
 List of supported Storage Pool Options for Kadalu:
- -
- -
- -
+
+[cols="50,50"]
+|===
+|Option |Value
+
+|performance.client-io-threads |on/off
+|performance.stat-prefetch     |on/off
+|performance.quick-read        |on/off
+|performance.open-behind       |on/off
+|performance.read-ahead        |on/off
+|performance.io-cache          |on/off
+|performance.readdir-ahead     |on/off
+|===
 
 * Configuring 'Storage Pool Options' through config file:
 +

--- a/doc/storage-config-options.adoc
+++ b/doc/storage-config-options.adoc
@@ -265,7 +265,7 @@ $ kubectl kadalu remove-archived-pv storage-pool-1 --pvc=pvc-e91ab8c8-4a48-48ad-
 ----
 
 * Removing archived pvc(s) through Kadalu CSI provisioner:
-
++
 Exec into Kadalu Provisioner pod. Run the script 'remove_archived_pv.py' with similar arguments as Kadalu CLI.
 +
 [source,console]
@@ -302,4 +302,63 @@ spec:
 ----
 $ kubectl kadalu storage-add storage-pool1 \
     --device kube1:/dev/vdc --volume-id=example-1234-volumeid-7890
+----
+
+== Configuring Storage Pool Options
+
+Storage Pool can be modified in their behaviour by configuring with Storage Pool Options available on Kadalu.
+Storage Pool Options can be configured either through storage-config file or using Kubectl Kadalu CLI.
+
+[TODO]
+List of supported Storage Pool Options for Kadalu:
+ -
+ -
+ -
+
+* Configuring 'Storage Pool Options' through config file:
++
+[source,yaml]
+----
+apiVersion: kadalu-operator.storage/v1alpha1
+kind: KadaluStorage
+metadata:
+# This will be used as name of PV Hosting Volume
+  name: storage1
+spec:
+  type: Replica1
+  options:
+    - key: "performance.quick-read"
+      value: "off"
+    - key: "performance.write-behind"
+      value: "on"
+  storage:
+    - node: kube1
+      device: /dev/vdc
+----
++
+If any further Storage Pool Options is to be configured, simply apply the modified storage-config file again so that Kadalu Operator notices the change and will be handled appropriately by Kadalu Server pods.
+
+* Configuring 'Storage Pool Options' through Kadalu CLI:
++
+To add/set Storage Pool Options, 'option-set' subcommand can be used. It expects name of Storage Pool and Option key(s) and value(s).
++
+[source,console]
+----
+$ kubectl kadalu option-set storage-pool1 \
+    performance.quick-read off performance.write-behind on
+----
++
+To remove/reset Storage Pool Options, 'option-reset' subcommand can be used. It expects name of Storage Pool and Option key(s) to be removed.
++
+[source,console]
+----
+$ kubectl kadalu option-reset storage-pool1 \
+    performance.quick-read performance.write-behind
+----
++
+Additionally all of configured options for a Storage Pool can be removed with '--all' flag.
++
+[source,console]
+----
+$ kubectl kadalu option-reset storage-pool1 --all
 ----


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
This PR adds two new sub-commands to Kubectl Kadalu CLI to support handling of Storage Pool Options.
- 'option-set': 
   Can configure Storage Pool Options as `$kubectl-kadalu option-set storage-pool-1 performance.quick-read on performance.write-behind off`
- 'option-reset':
   Remove a particular option as `$kubectl-kadalu option-reset storage-pool-1 performance.quick-read` 
   Or,
   Remove all options in a pool with `$kubectl-kadalu option-reset storage-pool-1 --all`
- Display all configured options in `storage-list` sub-command when `--detail` is used.


**Which issue(s) this PR fixes**:
Updates: #982 

**Checklist**
- [x] Documentation added
- [x] Tests updated [Will add it as new PR]
- [x] Add an entry in the `CHANGELOG.md` about the changes.
