### PR TITLE
Propagate error during failed mount when using external gluster volume.

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1100,8 +1100,8 @@ def mount_glusterfs_with_host(volname, mountpoint, hosts, options=None, is_clien
     try:
         execute(*command)
     except CommandException as excep:
-        if  excep.err.find("invalid option") != -1:
-            logging.info(logf(
+        if  excep.err.find("invalid option") != -1 or excep.err.find("unrecognized option") != -1:
+            logging.warning(logf(
                 "proceeding without supplied incorrect mount options",
                 options=g_ops,
                 ))
@@ -1109,13 +1109,13 @@ def mount_glusterfs_with_host(volname, mountpoint, hosts, options=None, is_clien
             try:
                 execute(*command)
             except CommandException as retry_err:
-                logging.info(logf(
+                logging.error(logf(
                     "mount command failed",
                     cmd=command,
                     error=retry_err,
                 ))
                 raise retry_err
-        logging.info(logf(
+        logging.error(logf(
             "mount command failed",
             cmd=command,
             error=excep,

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1108,19 +1108,19 @@ def mount_glusterfs_with_host(volname, mountpoint, hosts, options=None, is_clien
             command = cmd + [mountpoint]
             try:
                 execute(*command)
-            except CommandException as excep:
+            except CommandException as retry_err:
                 logging.info(logf(
                     "mount command failed",
                     cmd=command,
-                    error=excep,
+                    error=retry_err,
                 ))
-            return
+                raise retry_err
         logging.info(logf(
             "mount command failed",
             cmd=command,
             error=excep,
         ))
-    return
+        raise excep
 
 
 def check_external_volume(pv_request, host_volumes):


### PR DESCRIPTION
**What this PR does / why we need it**:
We now correctly propagate errors that can happen from the command during volume mount when using external gluster.  

Previously, these failed mount  
 error didn't bubble up and went to the upper caller, resulting in normal start-up/running pod and hide the problem.


**Which issue(s) this PR fixes**:
Fixes #1029