### PR TITLE
Skip SSH reachability check if quotas are disabled

### DIFF
--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -1028,16 +1028,16 @@ def handle_external_volume(volume, mountpoint, is_client, hosts):
     secret_private_key = "/etc/secret-volume/ssh-privatekey"
     secret_username = os.environ.get('SECRET_GLUSTERQUOTA_SSH_USERNAME', None)
 
-    # SSH into only first reachable host in volume['g_host'] entry
-    g_host = reachable_host(hosts)
-
-    if g_host is None:
-        logging.error(logf("All hosts are not reachable"))
-        return
-
     if use_gluster_quota is False:
         logging.debug(logf("Do not set quota-deem-statfs"))
     else:
+        # SSH into only first reachable host in volume['g_host'] entry
+        g_host = reachable_host(hosts)
+
+        if g_host is None:
+            logging.error(logf("All hosts are not reachable"))
+            return
+
         logging.debug(logf("Set quota-deem-statfs for gluster directory Quota"))
         quota_deem_cmd = [
             "ssh",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
Changes to SSH-reachability checks. The check will now only be done if SSH actually is needed to set the quotas. Before SSH-reachability always have been checked, which fails, if SSH is disabled or not using hardcoded port 22.

**Which issue(s) this PR fixes**:
Partly Fixes #1051
