### PR TITLE
Implement list-before-watch strategy for KaladuStorage

### DIFF
--- a/kadalu_operator/main.py
+++ b/kadalu_operator/main.py
@@ -880,7 +880,16 @@ def watch_stream(core_v1_client, k8s_client):
     """
     crds = client.CustomObjectsApi(k8s_client)
     k8s_watch = watch.Watch()
-    resource_version = ""
+    initial_list = crds.list_cluster_custom_object("kadalu-operator.storage",
+                                                   "v1alpha1",
+                                                   "kadalustorages")
+
+    for item in initial_list.get("items"):
+        handle_added(core_v1_client, item)
+
+    metadata = initial_list.get("metadata")
+    resource_version = metadata['resourceVersion']
+
     for event in k8s_watch.stream(crds.list_cluster_custom_object,
                                   "kadalu-operator.storage",
                                   "v1alpha1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
The operator is using "watch" to get notified of changes to kadaluStorages. The resourceVersion used to restart the watch - if disrupted - could be unknown to Kubernetes, because 
* they will be discarded after time
* the initial events when starting watch are not ordered by resourceVersion

As mentioned in https://github.com/kubernetes-client/python/blob/e0234d3e7193aea4b4e8f487cab0f1228f4386d2/kubernetes/base/watch/watch.py#L132 it is better to use a list as initial state and use the resourceVersion of the list as starting point for "watch".

**Which issue(s) this PR fixes**:
Fixes #1056