### PR TITLE
use socket with context manager while checking reachability

### DIFF
--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -91,8 +91,8 @@ def is_server_pod_reachable(hosts, port=24007, timeout=20):
         retry_count = 0
         while retry_count < 4:
             try:
-                sock = socket.create_connection((host, int(port)), timeout=timeout)
-                sock.shutdown(socket.SHUT_RDWR)
+                with socket.create_connection((host, int(port)), timeout=timeout) as sock:
+                    sock.shutdown(socket.SHUT_RDWR)
                 return True
             except socket.error:
                 logging.info(logf(
@@ -102,8 +102,6 @@ def is_server_pod_reachable(hosts, port=24007, timeout=20):
                 ))
                 time.sleep(30)
                 retry_count += 1
-            finally:
-                sock.close()
     return False
 
 


### PR DESCRIPTION
we check for server pod reachability by opening a socket connection and when pod is not reachable due to a programming mistake we always hit an exception w/o making any progress while closing sock.

There seems to be underlying bug as well, as we are returning from try w/o closing sock and so when pod is reachable we aren't hitting the issue.

``` py
File "/kadalu/kadalulib.py", line 106, in is_server_pod_reachable
sock.close()
UnboundLocalError: local variable 'sock' referenced before assignment
[2024-05-22 06:57:45,569] INFO [kadalulib - 432:monitor_proc] - Restarted Process name=csi
```

ref: #1069