### PR TITLE
Fix PVC mounting issues when 1st server pod is unavailable

### DIFF
--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -120,9 +120,9 @@ def is_server_pod_reachable(hosts, port=24007, timeout=20):
                 sockets.append(sock)
 
         # Only care about output sockets (not input or exception)
-        readable, writable, exceptional = select.select([], sockets, [], timeout)
+        _, writable, _ = select.select([], sockets, [], timeout)
 
-        if not (readable or writable or exceptional):
+        if not writable:
             logging.info(logf(
                     "Failed to connect to any server pod..."
                 ))

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -8,6 +8,8 @@ import sqlite3
 import subprocess
 import sys
 import time
+import select
+import errno
 
 import xxhash
 
@@ -87,23 +89,64 @@ def is_server_pod_reachable(hosts, port=24007, timeout=20):
     Returns False server pods are not reachable even after the timeout.
     """
 
-    for host in hosts:
-        retry_count = 0
-        while retry_count < 4:
-            try:
-                with socket.create_connection((host, int(port)), timeout=timeout) as sock:
-                    sock.shutdown(socket.SHUT_RDWR)
-                return True
-            except socket.error:
-                logging.info(logf(
-                    "Waiting for the server pod to come up...",
-                    server_pod=host,
-                    retry_count=retry_count+1
-                ))
-                time.sleep(30)
-                retry_count += 1
-    return False
+    connected = False
+    retry_count = 0
 
+    while retry_count < 4:
+        sockets = []
+
+        for host in hosts:
+            connect_started = False
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+                sock.setblocking(False)
+                sock.connect((host, int(port)))
+
+                connect_started = True
+
+            except socket.error as e:
+                if e.errno == errno.EINPROGRESS:
+                    connect_started = True
+                else:
+                    logging.info(logf(
+                        "Error encountered for server pod...",
+                        error=e,
+                        server_pod=host,
+                        retry_count=retry_count+1
+                    ))
+
+            if connect_started:
+                sockets.append(sock)
+
+        # Only care about output sockets (not input or exception)
+        readable, writable, exceptional = select.select([], sockets, [], timeout)
+
+        if not (readable or writable or exceptional):
+            logging.info(logf(
+                    "Failed to connect to any server pod..."
+                ))
+
+        for sock in writable:
+            logging.info(logf(
+                    "Connected to server pod...",
+                    server_pod=sock.getpeername()[0]
+                ))
+            connected = True
+
+        for sock in sockets:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except socket.error:
+                pass
+
+        if connected:
+            return True
+
+        time.sleep(30)
+        retry_count += 1
+
+    return False
 
 def is_host_reachable(hosts, port):
     """Check if glusterd is reachable in the given node"""

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -105,13 +105,13 @@ def is_server_pod_reachable(hosts, port=24007, timeout=20):
 
                 connect_started = True
 
-            except socket.error as e:
-                if e.errno == errno.EINPROGRESS:
+            except socket.error as msg:
+                if msg.errno == errno.EINPROGRESS:
                     connect_started = True
                 else:
                     logging.info(logf(
                         "Error encountered for server pod...",
-                        error=e,
+                        error=msg,
                         server_pod=host,
                         retry_count=retry_count+1
                     ))


### PR DESCRIPTION
When the first server pod is unavailable, kadalu is unable to mount with errors like "DeadlineExceeded".  This is due to the is_server_pod_reachable code which will iterate over the same server pod multiple times.  The original code would try 1st server pod, timeout in 20, sleep 30 seconds, and then retry 4 times.  This results in up to 200 seconds to determine that 1st server pod  is not reachable before trying the next.  This is too long to wait before responding when the issue may be isolated to the 1st server pod.

Given that it appears that the purpose of is_server_pod_reachable is to see if _any_ server pod is available, I rewrote it to function semi-asynchronously.  Basically, it will attempt to connect to all server pods at once and see if any succeeds.  If none succeeded, then sleep 30 seconds and retry.

<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:

It reduces the blocking in is_server_pod_reachable to minimum to determine whether any server pod is reachable.  This allows PVC mounting to continue when 1st server is not reachable but other server pods are reachable.

**Which issue(s) this PR fixes**:
Fixes mounting issues when 1st server pod is unavailable.