### PR TITLE
Modify grep-pattern to match only on white space word borders

### DIFF
--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -66,8 +66,8 @@ def is_gluster_mount_proc_running(volname, mountpoint):
     """
     cmd = (
         r'ps ax | grep -w "/opt/sbin/glusterfs" '
-        r'| grep -w "\-\-volfile\-id %s" '
-        r'| grep -w -q "%s"' % (volname, mountpoint)
+        r'| grep -w "\-\-volfile\-id %s " '
+        r'| grep -w -q "%s "' % (volname, mountpoint)
     )
 
     with subprocess.Popen(cmd,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
`grep -w` matches on all word borders, not only white space. Grepping for a volume `example-pv` will therefore also report a match on `example-pv-suffix`, leading to "No such file or directory:"-errors when trying to unmount `example-pv` in kadalu-provisioner.

**Which issue(s) this PR fixes**:
Fixes #1077

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
