### PR TITLE
Fix grep not matching volumes after PR #1090                                                                                           

### DIFF
--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -67,7 +67,7 @@ def is_gluster_mount_proc_running(volname, mountpoint):
     cmd = (
         r'ps ax | grep -w "/opt/sbin/glusterfs" '
         r'| grep -w "\-\-volfile\-id %s " '
-        r'| grep -w -q "%s "' % (volname, mountpoint)
+        r'| grep -G -q "%s$"' % (volname, mountpoint)
     )
 
     with subprocess.Popen(cmd,

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -66,8 +66,8 @@ def is_gluster_mount_proc_running(volname, mountpoint):
     """
     cmd = (
         r'ps ax | grep -w "/opt/sbin/glusterfs" '
-        r'| grep -w "\-\-volfile\-id %s " '
-        r'| grep -G -q "%s$"' % (volname, mountpoint)
+        r'| grep -- "--volfile-id %s " '
+        r'| grep -q "%s$"' % (volname, mountpoint)
     )
 
     with subprocess.Popen(cmd,

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -66,8 +66,8 @@ def is_gluster_mount_proc_running(volname, mountpoint):
     """
     cmd = (
         r'ps ax | grep -w "/opt/sbin/glusterfs" '
-        r'| grep -w "\-\-volfile\-id %s" '
-        r'| grep -w -q "%s"' % (volname, mountpoint)
+        r'| grep -w "\-\-volfile\-id %s " '
+        r'| grep -w -q "%s "' % (volname, mountpoint)
     )
 
     with subprocess.Popen(cmd,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
After implementing PR #1090 I noticed that grep will now never match to a volume, as the mountpoint in the output is always on the end of a line and will never have a trailing space. Changed the grep expression to match this expected output.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
