### PR TITLE
Improvement: Unmount unneeded gluster volumes on nodeserver

### DIFF
--- a/csi/Dockerfile
+++ b/csi/Dockerfile
@@ -14,7 +14,7 @@ RUN python3 -m pip install $(grep -vE '^(grpcio|\s*#)' /tmp/csi-requirements.txt
 FROM python:3.10-slim-bullseye as prod
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yq && \
-    apt-get install -y --no-install-recommends sqlite3 psmisc logrotate xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 libgoogle-perftools4 && \
+    apt-get install -y --no-install-recommends sqlite3 psmisc logrotate xfsprogs attr libtirpc3 bash inotify-tools ssh liburcu6 libgoogle-perftools4 tini && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -69,7 +69,8 @@ LABEL vcs-url="https://github.com/kadalu/kadalu"
 LABEL vendor="kadalu"
 LABEL version="${version}"
 
-ENTRYPOINT ["python3", "/kadalu/start.py"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["python3", "/kadalu/start.py"]
 
 # Debugging, Comment the above line and
 # uncomment below line

--- a/csi/controllerserver.py
+++ b/csi/controllerserver.py
@@ -222,7 +222,7 @@ class ControllerServer(csi_pb2_grpc.ControllerServicer):
                     # considered as to map 1 PV to 1 Gluster volume
 
                     # No need to keep the mount on controller
-                    unmount_glusterfs(mntdir)
+                    unmount_glusterfs(mntdir,ext_volume['g_volname'])
 
                     logging.info(logf(
                         "Volume (External) created",

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -8,8 +8,8 @@ import time
 import csi_pb2
 import csi_pb2_grpc
 import grpc
-from kadalulib import logf
-from volumeutils import mount_glusterfs, mount_volume, unmount_volume
+from kadalulib import logf, get_mounts_per_gvolname, get_gvolname_from_volumeid, get_mntdir_from_gvolname
+from volumeutils import mount_glusterfs, unmount_glusterfs, mount_volume, unmount_volume
 
 HOSTVOL_MOUNTDIR = "/mnt"
 GLUSTERFS_CMD = "/opt/sbin/glusterfs"
@@ -140,9 +140,25 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
 
         logging.debug(logf(
             "Received the unmount request",
-            volume=request.volume_id,
+            request=request,
         ))
+
+        gvolname = get_gvolname_from_volumeid(request.volume_id)
+
+        logging.debug(logf(
+            "Got gluster volume name %s" % gvolname
+        ))
+
         unmount_volume(request.target_path)
+
+        # If only PV mount is left, unmount this too
+        if get_mounts_per_gvolname(gvolname) == 1:
+            mntdir = get_mntdir_from_gvolname(gvolname)
+            logging.debug(logf(
+                "Only one mount left, going to unmount %s" % mntdir
+            ))
+
+            unmount_glusterfs(mntdir,gvolname)
 
         return csi_pb2.NodeUnpublishVolumeResponse()
 

--- a/csi/nodeserver.py
+++ b/csi/nodeserver.py
@@ -8,7 +8,7 @@ import time
 import csi_pb2
 import csi_pb2_grpc
 import grpc
-from kadalulib import logf, get_mounts_per_gvolname, get_gvolname_from_volumeid, get_mntdir_from_gvolname
+from kadalulib import logf, execute
 from volumeutils import mount_glusterfs, unmount_glusterfs, mount_volume, unmount_volume
 
 HOSTVOL_MOUNTDIR = "/mnt"
@@ -143,7 +143,15 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
             request=request,
         ))
 
-        gvolname = get_gvolname_from_volumeid(request.volume_id)
+        # Get the gluster volumename for a PVC volume ID
+        cmd = (
+            r'grep %s /proc/mounts '
+            r'| head -n 1 '
+            r'| cut -f 1 -d " " '
+            r'| cut -f 2 -d ":"' % (request.volume_id)
+        )
+
+        gvolname, _, _ = execute(cmd,shell=True)
 
         logging.debug(logf(
             "Got gluster volume name %s" % gvolname
@@ -151,9 +159,23 @@ class NodeServer(csi_pb2_grpc.NodeServicer):
 
         unmount_volume(request.target_path)
 
+        # Count remaining mounts
+        cmd = (
+            r'grep "fuse.glusterfs" /proc/mounts '
+            r'| grep ":%s " '
+            r'| wc -l' % (gvolname)
+        )
+
+        count, _, _ = execute(cmd,shell=True)
+
         # If only PV mount is left, unmount this too
-        if get_mounts_per_gvolname(gvolname) == 1:
-            mntdir = get_mntdir_from_gvolname(gvolname)
+        if int(count) == 1:
+            cmd = (
+                r'grep %s /proc/mounts '
+                r'| cut -f 2 -d " "' % (gvolname)
+            )
+
+            mntdir, _, _ = execute(cmd,shell=True)
             logging.debug(logf(
                 "Only one mount left, going to unmount %s" % mntdir
             ))

--- a/csi/volumeutils.py
+++ b/csi/volumeutils.py
@@ -775,6 +775,8 @@ def search_volume(volname):
 
     host_volumes = get_pv_hosting_volumes({})
     for volume in host_volumes:
+        if volname != volume['name']:
+            continue
         hvol = volume['name']
         mntdir = os.path.join(HOSTVOL_MOUNTDIR, hvol)
         mount_glusterfs(volume, mntdir)
@@ -888,10 +890,13 @@ def mount_volume(pvpath, mountpoint, pvtype, fstype=None):
     return True
 
 
-def unmount_glusterfs(mountpoint):
+def unmount_glusterfs(mountpoint,volname):
     """Unmount GlusterFS mount"""
-    volname = os.path.basename(mountpoint)
     if is_gluster_mount_proc_running(volname, mountpoint):
+        logging.debug(
+            logf("Executing unmount",
+                 volname=volname,
+                 mountpoint=mountpoint))
         execute(UNMOUNT_CMD, "-l", mountpoint)
 
 

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -132,6 +132,57 @@ def reachable_host(hosts):
             return host
     return None
 
+def get_gvolname_from_volumeid(volumeid):
+    """Returns the gluster volumename for a PVC volume ID"""
+    cmd = (
+        r'grep %s /proc/mounts '
+        r'| head -n 1 '
+        r'| cut -f 1 -d " " '
+        r'| cut -f 2 -d ":"' % (volumeid)
+    )
+
+    with subprocess.Popen(cmd,
+                          shell=True,
+                          stderr=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          universal_newlines=True) as proc:
+        out, err = proc.communicate()
+
+        return out.strip()
+
+def get_mntdir_from_gvolname(gvolname):
+    """Returns the mount directory for gluster volume name
+    Expectation is only one mount exists for the gluster volume"""
+    cmd = (
+        r'grep %s /proc/mounts '
+        r'| cut -f 2 -d " "' % (gvolname)
+    )
+
+    with subprocess.Popen(cmd,
+                          shell=True,
+                          stderr=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          universal_newlines=True) as proc:
+        out, err = proc.communicate()
+
+        return out.strip()
+
+def get_mounts_per_gvolname(gvolname):
+    """Returns how often a gluster volume is mounted"""
+    cmd = (
+        r'grep "fuse.glusterfs" /proc/mounts '
+        r'| grep ":%s " '
+        r'| wc -l' % (gvolname)
+    )
+
+    with subprocess.Popen(cmd,
+                          shell=True,
+                          stderr=subprocess.PIPE,
+                          stdout=subprocess.PIPE,
+                          universal_newlines=True) as proc:
+        out, err = proc.communicate()
+
+        return int(out)
 
 def makedirs(dirpath):
     """exist_ok=True parameter will raise exception even if directory

--- a/lib/kadalulib.py
+++ b/lib/kadalulib.py
@@ -132,57 +132,6 @@ def reachable_host(hosts):
             return host
     return None
 
-def get_gvolname_from_volumeid(volumeid):
-    """Returns the gluster volumename for a PVC volume ID"""
-    cmd = (
-        r'grep %s /proc/mounts '
-        r'| head -n 1 '
-        r'| cut -f 1 -d " " '
-        r'| cut -f 2 -d ":"' % (volumeid)
-    )
-
-    with subprocess.Popen(cmd,
-                          shell=True,
-                          stderr=subprocess.PIPE,
-                          stdout=subprocess.PIPE,
-                          universal_newlines=True) as proc:
-        out, err = proc.communicate()
-
-        return out.strip()
-
-def get_mntdir_from_gvolname(gvolname):
-    """Returns the mount directory for gluster volume name
-    Expectation is only one mount exists for the gluster volume"""
-    cmd = (
-        r'grep %s /proc/mounts '
-        r'| cut -f 2 -d " "' % (gvolname)
-    )
-
-    with subprocess.Popen(cmd,
-                          shell=True,
-                          stderr=subprocess.PIPE,
-                          stdout=subprocess.PIPE,
-                          universal_newlines=True) as proc:
-        out, err = proc.communicate()
-
-        return out.strip()
-
-def get_mounts_per_gvolname(gvolname):
-    """Returns how often a gluster volume is mounted"""
-    cmd = (
-        r'grep "fuse.glusterfs" /proc/mounts '
-        r'| grep ":%s " '
-        r'| wc -l' % (gvolname)
-    )
-
-    with subprocess.Popen(cmd,
-                          shell=True,
-                          stderr=subprocess.PIPE,
-                          stdout=subprocess.PIPE,
-                          universal_newlines=True) as proc:
-        out, err = proc.communicate()
-
-        return int(out)
 
 def makedirs(dirpath):
     """exist_ok=True parameter will raise exception even if directory
@@ -218,7 +167,7 @@ def get_volume_path(voltype, volhash, volname):
     )
 
 
-def execute(*cmd):
+def execute(*cmd,shell=False):
     """
     Execute command. Returns output and error.
     Raises CommandException on error
@@ -226,6 +175,7 @@ def execute(*cmd):
     with subprocess.Popen(cmd,
                           stderr=subprocess.PIPE,
                           stdout=subprocess.PIPE,
+                          shell=shell,
                           cwd=None,
                           universal_newlines=True) as proc:
         out, err = proc.communicate()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Before submitting:

1. Read our CONTRIBUTING.md guide
2. Name your PR as `<Feature Area>: Describe your change`.
  a. Start with an imperative verb. Example: Fix the latency between System A and System B.
  b. Use sentence case, not title case.
  c. Use a complete phrase or sentence. The PR title will appear in a changelog, so help other people understand what your change will be.
3. Rebase your PR if it gets out of sync with devel
-->

**What this PR does / why we need it**:
Nodeserver keeps all gluster volumes mounted even if they are no longer needed, i.e. the last pvc on the node has been removed. Using many gluster volumes in the kubernetes cluster will eventually result in excessive memory usage by nodeserver. This PR adds logic to remove the PV mount in nodeserver when all PVC mounts are released. Additionally, an init system (tini) is implemented for nodeserver pods, as unmounting an gluster volume left the glusterfs process as a zombie. Tini will take care of the zombie processes.

Also includes (and supersedes) PR #1094, fixing #1083:
1. gluster volumes were not unmounted, when gluster volume name and volume name differed
2. search_volume was looping through all available volumes, instead of just the one passed as parameter, mounting all available volumes in the process.

**Special notes for your reviewer**:
I only could test this PR with external gluster volumes. But I believe there should be no implications with kadalu-managed volumes, as this PR only affect nodeserver.


**Checklist**
- [ ] Documentation added
- [ ] Tests updated
- [ ] Add an entry in the `CHANGELOG.md` about the changes.
